### PR TITLE
base-files:fix order of ath9k and ath10k

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -21,6 +21,8 @@ boot() {
 	[ -f /proc/mounts ] || /sbin/mount_root
 	[ -f /proc/jffs2_bbc ] && echo "S" > /proc/jffs2_bbc
 
+	[ -f /etc/modules.d/ath9k ] && mv /etc/modules.d/ath9k /etc/modules.d/98-ath9k
+	[ -f /etc/modules.d/ath10k ] && mv /etc/modules.d/ath10k /etc/modules.d/99-ath10k
 	mkdir -p /var/run
 	mkdir -p /var/log
 	mkdir -p /var/lock


### PR DESCRIPTION
一个困扰我很久的问题，有时候2.4G在radio1 
这样更改后 2.4G就在radio0了 5G在radio1
在ar71xx dw33d测试通过