### PR TITLE
correct the HASH value of aaarch64 source pkg

### DIFF
--- a/package/ctcgfw/shadowsocks-rust/Makefile
+++ b/package/ctcgfw/shadowsocks-rust/Makefile
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:=https://github.com/shell-script/openwrt-shadowsocks-rust/release
 
 ifeq ($(ARCH),aarch64)
   PKG_SOURCE:=$(PKG_SOURCE_HEADER).aarch64-$(PKG_SOURCE_BODY).$(PKG_SOURCE_FOOTER)
-  PKG_HASH:=318e0538386e52025448e7dc1e67b71bd399981e386ba0a54802ff3c13b25016
+  PKG_HASH:=8e461614154d0d395f4e704ea170a6dac67401d92fe75e57e59ee33370bf1db6
 else ifeq ($(ARCH),arm)
   # Referred to golang/golang-values.mk
   ARM_CPU_FEATURES:=$(word 2,$(subst +,$(space),$(call qstrip,$(CONFIG_CPU_TYPE))))


### PR DESCRIPTION
sha256sum ./shadowsocks-v1.9.2.aarch64-unknown-linux-musl.tar.xz
8e461614154d0d395f4e704ea170a6dac67401d92fe75e57e59ee33370bf1db6  ./shadowsocks-v1.9.2.aarch64-unknown-linux-musl.tar.xz