### PR TITLE
Update 992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch

### DIFF
--- a/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -169,6 +169,7 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
 +&gpu {
 +	operating-points-v2 = <&gpu_opp_table>;
 +};
+
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
 @@ -14,7 +14,7 @@


### PR DESCRIPTION
fix