### PR TITLE
base-files:fix timezone error

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -24,7 +24,7 @@ system_config() {
 	rm -f /tmp/TZ
 	if [ -n "$zonename" ]; then
 		local zname=$(echo "$zonename" | tr ' ' _)
-		[ -f "/usr/share/zoneinfo/$zname" ] && ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime
+		[ -f "/usr/share/zoneinfo/$zname" ] && ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime || echo "$timezone" > /tmp/TZ
 	else
 		echo "$timezone" > /tmp/TZ
 	fi


### PR DESCRIPTION
the commit https://github.com/immortalwrt/immortalwrt/commit/3047df231743969ec2b4641d531e888b8c7f30e0 fixed zoneinfo support, but when zoneinfo package didnot installed, timezone setting don't work (always UTC).
fixed.

Signed-off-by: SiYao Mo <msylgj@vip.qq.com>