### PR TITLE
mac80211：Add the default locale to US and disable iw_qOS_MAP_set

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -176,7 +176,9 @@ detect_mac80211() {
 			set wireless.radio${devidx}.htmode=$htmode
 			set wireless.radio${devidx}.disabled=0
 
+			set wireless.radio${devidx}.country=US
 			set wireless.default_radio${devidx}=wifi-iface
+			set wireless.default_radio${devidx}.iw_qos_map_set=none
 			set wireless.default_radio${devidx}.device=radio${devidx}
 			set wireless.default_radio${devidx}.network=lan
 			set wireless.default_radio${devidx}.mode=ap


### PR DESCRIPTION
* “iw_qos_map_set”In the enabled case，Some devices won't start wirelessly。This is due to the introduction of new features on hostpad，Official patches have been added, but they still don't work。
* Adding the default area to US is also said to help improve wireless。