### PR TITLE
imagebuilder: remove default package luci-app-cpufreq

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -96,6 +96,7 @@ endif
 	$(SED) 's,^# REVISION:=.*,REVISION:=$(REVISION),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) 's,^# SOURCE_DATE_EPOCH:=.*,SOURCE_DATE_EPOCH:=$(SOURCE_DATE_EPOCH),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) '/LINUX_VERMAGIC:=/ { s,unknown,$(LINUX_VERMAGIC),g }' $(PKG_BUILD_DIR)/include/kernel.mk
+	$(SED) '/luci-app-cpufreq/d' $(PKG_BUILD_DIR)/include/target.mk
 	find $(PKG_BUILD_DIR) -name CVS -o -name .git -o -name .svn \
 	  | $(XARGS) rm -rf
 	$(INSTALL_DIR) $(IB_IDIR)


### PR DESCRIPTION
Package luci-app-cpufreq is a global package at include/target.mk, but many devices don't build it by default (CPU platform restricted).
When we use imagebuilder to generate firmwares, the devices that not build luci-app-cpufreq by default will throw a error:
"opkg_install_cmd: Cannot install package luci-app-cpufreq."
So remove package luci-app-cpufreq at imagebuilder is a good idea.