### PR TITLE
mac80211： enable iw_qos_map_set

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -183,7 +183,6 @@ detect_mac80211() {
 			set wireless.default_radio${devidx}.mode=ap
 			set wireless.default_radio${devidx}.ssid=OpenWrt
 			set wireless.default_radio${devidx}.encryption=none
-			set wireless.default_radio${devidx}.iw_qos_map_set=none
 EOF
 		uci -q commit wireless
 


### PR DESCRIPTION
An upstream repair caused the wireless to fail to start