### PR TITLE
fix ubus luci.getConntrackHelpers call with firewall4

### DIFF
--- a/package/emortal/autocore/files/arm/rpcd_luci
+++ b/package/emortal/autocore/files/arm/rpcd_luci
@@ -165,7 +165,11 @@ local methods = {
 			local ok, fd = pcall(io.open, "/usr/share/fw3/helpers.conf", "r")
 			local rv = {}
 
-			if ok then
+			if not (ok and fd) then
+				ok, fd = pcall(io.open, "/usr/share/firewall4/helpers", "r")
+			end
+
+			if ok and fd then
 				local entry
 
 				while true do


### PR DESCRIPTION
Fallback to firewall4's helper list if the fw3 one cannot be loaded.
Fixes broken zone configuration when firewall4 is installed as backend.