### PR TITLE
fullconenat: fix _init repeat definition

### DIFF
--- a/package/network/utils/fullconenat/patches/001-fix-init-Repeat-definition.patch
+++ b/package/network/utils/fullconenat/patches/001-fix-init-Repeat-definition.patch
@@ -1,0 +1,20 @@
+--- a/libip6t_FULLCONENAT.c
++++ b/libip6t_FULLCONENAT.c
+@@ -214,6 +214,7 @@ static struct xtables_target fullconenat_tg_reg = {
+ 	.x6_options	= FULLCONENAT_opts,
+ };
+ 
++#define _init __attribute__((constructor)) _INIT
+ void _init(void)
+ {
+ 	xtables_register_target(&fullconenat_tg_reg);
+--- a/libipt_FULLCONENAT.c
++++ b/libipt_FULLCONENAT.c
+@@ -235,6 +235,7 @@ static struct xtables_target fullconenat_tg_reg = {
+ 	.x6_options	= FULLCONENAT_opts,
+ };
+ 
++#define _init __attribute__((constructor)) _INIT
+ void _init(void)
+ {
+ 	xtables_register_target(&fullconenat_tg_reg);


### PR DESCRIPTION
After iptables was updated to 1.8.8, a compilation error occurred during fullconenat compilation due to _init redefinition.