### PR TITLE
rtl8812au-ct: Fix compile

### DIFF
--- a/package/kernel/rtl8812au-ct/patches/004-remove-extern-inline.patch
+++ b/package/kernel/rtl8812au-ct/patches/004-remove-extern-inline.patch
@@ -1,0 +1,24 @@
+--- a/include/ieee80211.h
++++ b/include/ieee80211.h
+@@ -1313,18 +1313,18 @@ enum ieee80211_state {
+ (((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
+ (((Addr[5]) & 0xff) == 0xff))
+ #else
+-extern __inline int is_multicast_mac_addr(const u8 *addr)
++__inline static int is_multicast_mac_addr(const u8 *addr)
+ {
+ 	return ((addr[0] != 0xff) && (0x01 & addr[0]));
+ }
+ 
+-extern __inline int is_broadcast_mac_addr(const u8 *addr)
++__inline static int is_broadcast_mac_addr(const u8 *addr)
+ {
+ 	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
+ 	        (addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+ }
+ 
+-extern __inline int is_zero_mac_addr(const u8 *addr)
++__inline static int is_zero_mac_addr(const u8 *addr)
+ {
+ 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
+ 	        (addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));


### PR DESCRIPTION
Replace the extern inline with a static inline. With extern inline the compiler will generate the function in all compile units including this file which breaks linking later.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>


copy from mainline  https://github.com/openwrt/openwrt/commit/63460a5ba2fdf227f02023f9674330e28f6c82fe