### PR TITLE
mediatek: easy install for Xiaomi Redmi Router AX6000

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
@@ -186,15 +186,20 @@
 				read-only;
 			};
 
+			partition@600000 {
+				label = "ubi_kernel";
+				reg = <0x600000 0x1e00000>;
+			};
+
 			/* ubi partition is the result of squashing
 			 * consecutive stock partitions:
 			 * - ubi
 			 * - ubi1
 			 * - overlay
 			 */
-			partition@600000 {
+			partition@2400000 {
 				label = "ubi";
-				reg = <0x600000 0x6e00000>;
+				reg = <0x2400000 0x5000000>;
 			};
 
 			/* last 12 MiB is reserved for NMBM bad block table */

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,129 @@
 REQUIRE_IMAGE_METADATA=1
 
+redmi_ax6000_nand_upgrade_tar()
+{
+	CI_UBIPART=ubi
+	local tar_file="$1"
+	local board_dir="$(tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$')"
+	board_dir="${board_dir%/}"
+
+	local kernel_length=$( (tar xf "$tar_file" "$board_dir/kernel" -O | wc -c) 2> /dev/null)
+	[ "$kernel_length" = 0 ] && kernel_length=
+
+	local rootfs_length=$( (tar xf "$tar_file" "$board_dir/root" -O | wc -c) 2> /dev/null)
+	[ "$rootfs_length" = 0 ] && rootfs_length=
+
+	local rootfs_type
+	[ "$rootfs_length" ] && rootfs_type="$(identify_tar "$tar_file" "$board_dir/root")"
+
+	[ -n "$rootfs_length" -o -n "$kernel_length" ] || return 1
+
+	local mtdnum="$( find_mtd_index "$CI_UBIPART" )"
+	if [ ! "$mtdnum" ]; then
+		echo "cannot find ubi mtd partition ubi"
+		return 1
+	fi
+	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+	#cleanup old data volume if exist
+	if [ "$ubidev" ] && [ "$( nand_find_volume $ubidev data )" ]; then
+		ubidetach -m "$mtdnum"
+		ubiformat /dev/mtd$mtdnum -y
+		ubiattach -m "$mtdnum"
+		ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+	fi
+	if [ ! "$ubidev" ]; then
+		ubiattach -m "$mtdnum"
+		ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+		if [ ! "$ubidev" ]; then
+			ubiformat /dev/mtd$mtdnum -y
+			ubiattach -m "$mtdnum"
+			ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+
+			if [ ! "$ubidev" ]; then
+				echo "cannot attach ubi mtd partition ubi"
+				return 1
+			fi
+		fi
+	fi
+
+	local kern_mtdnum="$( find_mtd_index "ubi_kernel" )"
+	if [ ! "$kern_mtdnum" ]; then
+		echo "cannot find ubi_kernel mtd partition ubi_kernel"
+		return 1
+	fi
+	local kern_ubidev="$( nand_find_ubi "ubi_kernel" )"
+	if [ ! "$kern_ubidev" ]; then
+		ubiattach -m "$kern_mtdnum"
+		kern_ubidev="$( nand_find_ubi "ubi_kernel" )"
+		if [ ! "$kern_ubidev" ]; then
+			ubiformat /dev/mtd$kern_mtdnum -y
+			ubiattach -m "$kern_mtdnum"
+			kern_ubidev="$( nand_find_ubi "ubi_kernel" )"
+			if [ ! "$kern_ubidev" ]; then
+				echo "cannot attach ubi_kernel mtd partition ubi_kernel"
+				return 1
+			fi
+		fi
+	fi
+
+	local kern_ubivol="$( nand_find_volume $kern_ubidev "kernel" )"
+	local root_ubivol="$( nand_find_volume $ubidev "rootfs" )"
+	local data_ubivol="$( nand_find_volume $ubidev rootfs_data )"
+
+	[ "$kern_ubivol" ] && { nand_remove_ubiblock $kern_ubivol || return 1; }
+	[ "$root_ubivol" ] && { nand_remove_ubiblock $root_ubivol || return 1; }
+	[ "$data_ubivol" ] && { nand_remove_ubiblock $data_ubivol || return 1; }
+
+	[ "$data_ubivol" ] && ubirmvol /dev/$ubidev -N rootfs_data || :
+	[ "$root_ubivol" ] && ubirmvol /dev/$ubidev -N "rootfs" || :
+	ubirmvol /dev/$kern_ubidev -N rootfs_data 2>/dev/null || :
+	ubirmvol /dev/$kern_ubidev -N rootfs 2>/dev/null || :
+	[ "$kern_ubivol" ] && ubirmvol /dev/$kern_ubidev -N "kernel" || :
+
+	# create kernel vol in ubi_kernel
+	if ! ubimkvol /dev/$kern_ubidev -N "kernel" -s $kernel_length; then
+		echo "cannot create kernel volume"
+		return 1
+	fi
+
+	# create rootfs vol in ubi
+	local rootfs_size_param
+	if [ "$rootfs_type" = "ubifs" ]; then
+		rootfs_size_param="-m"
+	else
+		rootfs_size_param="-s $rootfs_length"
+	fi
+	if ! ubimkvol /dev/$ubidev -N "rootfs" $rootfs_size_param; then
+		echo "cannot create rootfs volume"
+		return 1;
+	fi
+
+	# create rootfs_data vol for non-ubifs rootfs in ubi
+	if [ "$rootfs_type" != "ubifs" ]; then
+		local rootfs_data_size_param="-m"
+		if ! ubimkvol /dev/$ubidev -N rootfs_data $rootfs_data_size_param; then
+			if ! ubimkvol /dev/$ubidev -N rootfs_data -m; then
+				echo "cannot initialize rootfs_data volume"
+				return 1
+			fi
+		fi
+	fi
+
+	root_ubivol="$( nand_find_volume $ubidev "rootfs" )"
+	if [ "$root_ubivol" ]; then
+		tar xf "$tar_file" "$board_dir/root" -O | \
+			ubiupdatevol /dev/$root_ubivol -s $rootfs_length -
+	fi
+
+	kern_ubivol="$( nand_find_volume $kern_ubidev "kernel" )"
+	if [ "$kern_ubivol" ]; then
+		tar xf "$tar_file" "$board_dir/kernel" -O | \
+			ubiupdatevol /dev/$kern_ubivol -s $kernel_length -
+	fi
+
+	nand_do_upgrade_success
+}
+
 platform_do_upgrade() {
 	local board=$(board_name)
 
@@ -20,6 +144,9 @@ platform_do_upgrade() {
 			nand_do_upgrade "$1"
 			;;
 		esac
+		;;
+	xiaomi,redmi-router-ax6000)
+		redmi_ax6000_nand_upgrade_tar "$1"
 		;;
 	*)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
1. gen initramfs-factory.ubi for esay installation usage
2. change the nand flash layout to make it possible to revert back to stock firmware.

Here adjust the flash partition layout to avoid modifying the uboot env of mtdparts. This implementation is to keep the 30M ubi_kernel partition aligned with the stock ubi partition, and put the kernel volume into it, the stock uboot could boot from it, without changing the `mtdparts`
This is very helpfull to make it possible to revert back to stock firmware using the Xiaomi Firmware Tools. According to the actual test, if mtdparts is modified, it broke Xiaomi Firmware Tools to work.

Also add new sysupgrade script function to make sysupgrade possible for this new layout.

New flash instructions:
1. Gain ssh access (see the link: https://openwrt.org/toh/xiaomi/redmi_ax6000#installation)
2. Check current stock system COMMAND: `cat /proc/cmdline` sample OUTPUT: `console=ttyS0,115200n1 loglevel=8 firmware=1 uart_en=1` if firmware=1, current system is ubi1 if firmware=0, current system is ubi0
3. Setup nvram if current system is ubi1, please setup: next time it would boot from ubi
```
nvram set boot_wait=on
nvram set uart_en=1
nvram set flag_boot_rootfs=0
nvram set flag_last_success=0
nvram set flag_boot_success=1
nvram set flag_try_sys1_failed=0
nvram set flag_try_sys2_failed=0
nvram commit
```
   else if current system is ubi, please setup: next time it would boot from ubi1
```
nvram set boot_wait=on
nvram set uart_en=1
nvram set flag_boot_rootfs=1
nvram set flag_last_success=1
nvram set flag_boot_success=1
nvram set flag_try_sys1_failed=0
nvram set flag_try_sys2_failed=0
nvram commit
```
4. Flash flash initramfs-factory.ubi if firmware=1, current system is ubi1, flash to ubi: `ubiformat /dev/mtd8 -y -f /tmp/initramfs-factory.ubi` if firmware=0, current system is ubi, flash to ubi1: `ubiformat /dev/mtd9 -y -f /tmp/initramfs-factory.ubi`
5. Reboot and setup uboot-env reboot then it should boot to the openwrt initramfs system now, login ssh and setup:
```
fw_setenv boot_wait on
fw_setenv uart_en 1
fw_setenv flag_boot_rootfs 0
fw_setenv flag_last_success 1
fw_setenv flag_boot_success 1
fw_setenv flag_try_sys1_failed 8
fw_setenv flag_try_sys2_failed 8
fw_setenv mtdparts "nmbm0:1024k(bl2),256k(Nvram),256k(Bdata),2048k(factory),2048k(fip),256k(crash),256k(crash_log),30720k(ubi),30720k(ubi1),51200k(overlay)"
```
   here set flag_last_success=1 and flag_try_sys1_failed >= 6 and flag_try_sys1_failed >=6, to make it always boot from system 0
6. Flash sysupgrade.bin via sysupgrade
```
sysupgrade -n /tmp/squashfs-sysupgrade.bin
```

Signed-off-by: Chen Minqiang <ptpt52@gmail.com>