### PR TITLE
Add support for HiWiFi R33, fix 'eth0 transmit timed out' for mt7620 switch.

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -263,6 +263,8 @@ struct rtl8367b_initval {
 	u16 val;
 };
 
+u32 rtl_device_id;
+
 #define RTL8367B_MIB_RXB_ID		0	/* IfInOctets */
 #define RTL8367B_MIB_TXB_ID		28	/* IfOutOctets */
 
@@ -611,6 +613,10 @@ static int rtl8367b_write_initvals(struct rtl8366_smi *smi,
 {
 	int err;
 	int i;
+
+	if (rtl_device_id == 0x0020) {
+							return 0;
+		}
 
 	for (i = 0; i < count; i++)
 		REG_WR(smi, initvals[i].reg, initvals[i].val);
@@ -1539,8 +1545,11 @@ static int rtl8367b_detect(struct rtl8366_smi *smi)
 			"chip mode");
 		return ret;
 	}
+	rtl_device_id = chip_ver;
+
 
 	switch (chip_ver) {
+	case 0x0020:
 	case 0x1000:
 		chip_name = "8367RB";
 		break;

--- a/target/linux/ramips/dts/mt7620a_hiwifi_r33.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_r33.dts
@@ -1,0 +1,236 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hiwifi,r33", "ralink,mt7620a-soc";
+	model = "HiWiFi R33";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	nand {
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "mtk,mt7620-nand";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "debug";
+				reg = <0x80000 0x80000>;
+				read-only;
+			};
+
+			factory: partition@100000 {
+				label = "factory";
+				reg = <0x100000 0x40000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "kernel";
+				reg = <0x140000 0x400000>;
+			};
+
+			ubiconcat0: partition@540000 {
+				label = "ubiconcat0";
+				reg = <0x540000 0x1c80000>;
+			};
+
+			partition@21c0000 {
+				label = "bdinfo";
+				reg = <0x21c0000 0x80000>;
+				read-only;
+			};
+
+			ubiconcat1: partition@2240000 {
+				label = "ubiconcat1";
+				reg = <0x2240000 0x5dc0000>;
+			};
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x7a40000>;
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_system: system {
+			label = "blue:system";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		turbo {
+			label = "blue:turbo";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "none";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		internet {
+			label = "blue:internet";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <0>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b", "rtl8367b";
+		cpu_port = <6>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+	};
+};
+
+//在最新的openwrt master分支中sysc已经被剔除，此处进行备份标记
+// &sysc {
+// 	ralink,gpiomux = "i2c", "jtag";
+// 	ralink,uartmux = "gpio";
+// 	ralink,wdtmux = <1>;
+// };
+
+&gpio3 {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	//mtd-mac-address = <&factory 0x4>;
+
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+//5G WIFI
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		// nvmem-cells = <&macaddr_factory_4>;
+		// nvmem-cell-names = "mac-address";
+		// mac-address-increment = <2>;
+	};
+};
+
+//2.4G WIFI
+&wmac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+	ralink,mtd-eeprom = <&factory 0x0>;
+	// nvmem-cells = <&macaddr_factory_4>;
+	// nvmem-cell-names = "mac-address";
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "wled";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -909,7 +909,6 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 	struct fe_rx_dma *rxd, trxd;
 	int done = 0, pad;
 
-	fe_reg_w32(rx_intr, FE_REG_FE_INT_STATUS);
 
 	if (netdev->features & NETIF_F_RXCSUM)
 		checksum_bit = soc->checksum_bit;
@@ -1003,6 +1002,9 @@ release_desc:
 		done++;
 	}
 
+	if (done < budget)
+		fe_reg_w32(rx_intr, FE_REG_FE_INT_STATUS);
+
 	return done;
 }
 
@@ -1017,7 +1019,6 @@ static int fe_poll_tx(struct fe_priv *priv, int budget, u32 tx_intr,
 	u32 idx, hwidx;
 	struct fe_tx_ring *ring = &priv->tx_ring;
 
-	fe_reg_w32(tx_intr, FE_REG_FE_INT_STATUS);
 
 	idx = ring->tx_free_idx;
 	hwidx = fe_reg_r32(FE_REG_TX_DTX_IDX0);
@@ -1042,7 +1043,9 @@ static int fe_poll_tx(struct fe_priv *priv, int budget, u32 tx_intr,
 	if (idx == hwidx) {
 		/* read hw index again make sure no new tx packet */
 		hwidx = fe_reg_r32(FE_REG_TX_DTX_IDX0);
-		if (idx != hwidx)
+		if (idx == hwidx)
+			fe_reg_w32(tx_intr, FE_REG_FE_INT_STATUS);
+		else
 			*tx_again = 1;
 	} else {
 		*tx_again = 1;

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -516,6 +516,27 @@ define Device/hiwifi_hc5861
 endef
 TARGET_DEVICES += hiwifi_hc5861
 
+define Device/hiwifi_r33
+  SOC := mt7620a
+  DEVICE_VENDOR := HiWiFi
+  DEVICE_MODEL := R33
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+	kmod-switch-rtl8366-smi kmod-switch-rtl8367b kmod-mt76x2
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := 32768k
+  IMAGES += kernel.bin rootfs.bin factory.bin
+  IMAGE/kernel.bin := append-kernel | check-size $$$$(KERNEL_SIZE)
+  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  SUPPORTED_DEVICES += r33
+endef
+TARGET_DEVICES += hiwifi_r33
+
 define Device/hnet_c108
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -122,6 +122,9 @@ hiwifi,hc5761)
 hiwifi,hc5861)
 	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch0" "0x20"
 	;;
+hiwifi,r33)
+	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch1" "0x01"
+	;;
 hnet,c108)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	ucidef_set_led_netdev "modem" "modem" "green:modem" "wwan0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -167,6 +167,13 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "5:wan" "6@eth0"
 		;;
+	hiwifi,r33)
+		ucidef_add_switch "switch0" \
+			"6@eth0"
+		ucidef_add_switch_attr "switch0" "enable" "false"
+		ucidef_add_switch "switch1" \
+			"1:lan" "2:lan" "0:wan" "6@eth0"
+		;;
 	iodata,wn-ac1167gr|\
 	iodata,wn-ac733gr3|\
 	iptime,a1004ns)
@@ -335,6 +342,12 @@ ramips_setup_macs()
 	hiwifi,hc5661|\
 	hiwifi,hc5761|\
 	hiwifi,hc5861)
+		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		label_mac=$lan_mac
+		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	hiwifi,r33)
 		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
 		label_mac=$lan_mac
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -23,4 +23,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
 		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
 		;;
+	hiwifi,r33)
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		[ "$PHYNBR" = "1" ] && [ -n "$label_mac" ] && \
+		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
+		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
+		;;
 esac

--- a/target/linux/ramips/mt7620/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7620/base-files/lib/upgrade/platform.sh
@@ -34,6 +34,9 @@ platform_do_upgrade() {
 		dd if=/dev/mtd0 bs=64 count=1 2>/dev/null | grep -qi breed && CI_KERNPART_EXT="kernel_stock"
 		nand_do_upgrade "$1"
 		;;
+	hiwifi,r33)
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
添加由zfdx123提供的对极路由3 Pro（HiWiFi R33 | C312B)的支持，跟进上游openwrt的mtk交换机驱动以修复MT7620的大流量断流问题。