### PR TITLE
openssl-3.08： Fixed firmware unable to page and command line upgrade!

### DIFF
--- a/package/libs/openssl/files/devcrypto.cnf
+++ b/package/libs/openssl/files/devcrypto.cnf
@@ -26,6 +26,6 @@ default_algorithms = ALL
 # is poor, and there are many cases in which they will not work,
 # especially when calling fork with open crypto contexts.  Openssh,
 # for example, does this, and you may not be able to login.
-#DIGESTS = NONE
+DIGESTS = NONE
 
 


### PR DESCRIPTION
It is strongly recommended not to enable digests;   their performance is poor, and there are many cases in which they will not work,
especially when calling fork with open crypto contexts for example firmware cannot be upgraded