### PR TITLE
Fix bolt bl201 dts and update some device related value

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
@@ -81,10 +81,22 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
 };
 
 &gpio3 {
@@ -107,12 +119,12 @@
 			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x30000>;
+				read-only;
 			};
 
 			partition@30000 {
 				label = "u-boot-env";
 				reg = <0x30000 0x10000>;
-				read-only;
 			};
 
 			factory: partition@40000 {
@@ -126,15 +138,36 @@
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};
+
+			partition@fd0000 {
+				label = "crash";
+				reg = <0xfd0000 0x10000>;
+			};
+
+			partition@fe0000 {
+				label = "reserved";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "Bdata";
+				reg = <0xff0000 0x10000>;
+			};
 		};
 	};
 };
 
-&ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
+&ehci {
+	status = "okay";
+};
 
-	nvmem-cells = <&macaddr_factory_4>;
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
 	nvmem-cell-names = "mac-address";
 
 	mediatek,portmap = "llllw";
@@ -160,7 +193,7 @@
 
 &state_default {
 	gpio {
-		groups = "wled", "i2c", "uartf", "wdt";
+		groups = "i2c", "uartf", "rgmii1", "rgmii2", "ephy", "wled", "nd_sd";
 		function = "gpio";
 	};
 };
@@ -170,7 +203,7 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -41,8 +41,8 @@ bdcom,wap2100-sk)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
 bolt,bl201)
-	ucidef_set_led_netdev "wlan0" "wlan0-link" "blue:wlan" "wlan0"
-	ucidef_set_led_netdev "wan" "eth0.2-link" "blue:wan" "eth0.2" "link"
+	ucidef_set_led_netdev "phy0-ap0" "phy0-ap0" "blue:wlan" "phy0-ap0"
+	ucidef_set_led_netdev "wan" "eth0.2" "blue:wan" "eth0.2"
 	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -11,7 +11,6 @@ ramips_setup_interfaces()
 	aigale,ai-br100|\
 	alfa-network,ac1200rm|\
 	asus,rt-n12p|\
-	bolt,bl201|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
@@ -35,6 +34,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	alfa-network,r36m-e4g|\
+	bolt,bl201|\
 	zbtlink,zbt-we1026-h-32m)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"


### PR DESCRIPTION
## Changes:

1. add bolt_bl201 LED aliases
2. fix bolt_bl201 restart key gpio
3. make bolt_bl201 bootloader read-only
4. add bolt_bl201 partition settings
5. fix bolt_bl201 wrong gpio group
6. update bolt_bl201 LED and network switch settings