### PR TITLE
autocore:  Temperature display supports virtual machines.

### DIFF
--- a/package/emortal/autocore/files/cpuinfo
+++ b/package/emortal/autocore/files/cpuinfo
@@ -38,7 +38,9 @@ case "$DISTRIB_TARGET" in
 "bcm27xx"/*)
 	cpu_temp="$(vcgencmd measure_temp | awk -F '=' '{print $2}' | awk -F "'" '{print $1}')°C" ;;
 "x86"/*)
-	if grep -q "GenuineIntel" "/proc/cpuinfo"; then
+	if uci get wechatpush.config.server_host >/dev/null 2>&1; then
+		cpu_temp="$(/usr/share/wechatpush/wechatpush soc)°C"
+	elif grep -q "GenuineIntel" "/proc/cpuinfo"; then
 		cpu_temp="$(sensors "coretemp-*" 2>"/dev/null" | grep -E "(Package id |Core )" | grep -Eo "\+[0-9.]*°C" | head -n1 | tr -d "+")"
 	elif grep -q "AuthenticAMD" "/proc/cpuinfo"; then
 		cpu_temp="$(sensors "k*temp-*" 2>"/dev/null" | awk '/Tdie/ {print $2}' | head -n1 | tr -d "+")"

--- a/package/emortal/autocore/files/cpuinfo
+++ b/package/emortal/autocore/files/cpuinfo
@@ -38,7 +38,7 @@ case "$DISTRIB_TARGET" in
 "bcm27xx"/*)
 	cpu_temp="$(vcgencmd measure_temp | awk -F '=' '{print $2}' | awk -F "'" '{print $1}')°C" ;;
 "x86"/*)
-	if uci get wechatpush.config.server_host >/dev/null 2>&1; then
+	if [ -n "$(uci -q get "wechatpush.config.server_host")" ]; then
 		cpu_temp="$(/usr/share/wechatpush/wechatpush soc)°C"
 	elif grep -q "GenuineIntel" "/proc/cpuinfo"; then
 		cpu_temp="$(sensors "coretemp-*" 2>"/dev/null" | grep -E "(Package id |Core )" | grep -Eo "\+[0-9.]*°C" | head -n1 | tr -d "+")"


### PR DESCRIPTION
It is possible to display the host machine's temperature on the "Overview" page of OpenWrt running in a virtual machine. However, to enable this feature, additional configuration is required, including setting up SSH keys and providing the host machine's IP address. Therefore, the command actually checks whether the "luci-app-wechatpush" plugin has enabled the feature to retrieve the host machine's temperature. If it is enabled, the command will invoke /usr/share/wechatpush/wechatpush soc to obtain the temperature.