### PR TITLE
autocore: add targetid qualcommax

### DIFF
--- a/package/emortal/autocore/Makefile
+++ b/package/emortal/autocore/Makefile
@@ -42,7 +42,7 @@ endif
 
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) ./files/cpuinfo $(1)/sbin/
-ifneq ($(filter ipq% mediatek%, $(TARGETID)),)
+ifneq ($(filter ipq% mediatek% qualcommax%, $(TARGETID)),)
 	$(INSTALL_BIN) ./files/tempinfo $(1)/sbin/
 endif
 


### PR DESCRIPTION
the upstream main has this change: ipq807x: rename target to qualcommax(https://github.com/openwrt/openwrt/pull/12923/commits/f02f6aaa8d4e1025ab4aa9f569123e57f689f4e5) so the ipq807x/generic is renamed to qualcommax/ipq807x, and the tempinfo in autocore get lost

therefore, update filter to re-enable tempinfo on qualcommax/ipq807x