### PR TITLE
default-settings-chn: specifies the country code

### DIFF
--- a/package/emortal/default-settings/files/99-default-settings-chinese
+++ b/package/emortal/default-settings/files/99-default-settings-chinese
@@ -12,6 +12,12 @@ uci -q batch <<-EOF
 EOF
 uci commit system
 
+if [ -f "/etc/config/wireless" ];then
+	uci set wireless.@wifi-device[0].country='CN'
+	uci set wireless.@wifi-device[1].country='CN'
+	uci commit wireless
+fi
+
 sed -i 's,downloads.immortalwrt.org,mirrors.vsean.net/openwrt,g' /etc/opkg/distfeeds.conf
 
 exit 0


### PR DESCRIPTION
Set the country code of the wireless device for Chinese users to `CN`.

Currently there is no determination of whether the device is single or dual band, no adaptation to multi-band of three bands and above, and the code needs refinement.

`help wanted`