### PR TITLE
rockchip: refresh patches

### DIFF
--- a/target/linux/rockchip/patches-5.15/804-02-PM-devfreq-event-add-support-for-rk3368-dfi.patch
+++ b/target/linux/rockchip/patches-5.15/804-02-PM-devfreq-event-add-support-for-rk3368-dfi.patch
@@ -174,11 +174,12 @@ Signed-off-by: Finley Xiao <finley.xiao@rock-chips.com>
  	data->regs = devm_platform_ioremap_resource(pdev, 0);
  	if (IS_ERR(data->regs))
  		return PTR_ERR(data->regs);
-@@ -206,23 +291,58 @@ static int rockchip_dfi_probe(struct pla
- 	if (IS_ERR(data->regmap_pmu))
- 		return PTR_ERR(data->regmap_pmu);
- 
+@@ -205,23 +290,59 @@ static int rockchip_dfi_probe(struct pla
+ 		if (IS_ERR(data->regmap_pmu))
+ 			return PTR_ERR(data->regmap_pmu);
+ 	}
 -	data->dev = dev;
++
 +	desc->ops = &rockchip_dfi_ops;
 +
 +	return 0;


### PR DESCRIPTION
Fix compilation errors caused by incorrect cherry-pick.