### PR TITLE
Add ZTE E8820S MTK SDK partition support for flashing via Breed.

### DIFF
--- a/target/linux/ramips/dts/mt7621_zte_e8820s-breed.dts
+++ b/target/linux/ramips/dts/mt7621_zte_e8820s-breed.dts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_zte_e8820s.dtsi"
+
+/ {
+	compatible = "zte,e8820s-breed", "mediatek,mt7621-soc";
+	model = "ZTE E8820S (MTK SDK Partition)";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0 0x80000>;
+		read-only;
+	};
+
+	partition@80000 {
+		label = "u-boot-env";
+		reg = <0x80000 0x80000>;
+		read-only;
+	};
+
+	factory: partition@100000 {
+		compatible = "nvmem-cells";
+		label = "factory";
+		reg = <0x100000 0x40000>;
+		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_config_12: macaddr@e000 {
+				compatible = "mac-base";
+				reg = <0xe000 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
+
+			eeprom_factory_f000: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			eeprom_factory_f800: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
+		};
+	};
+
+	partition@140000 {
+		label = "kernel";
+		reg = <0x140000 0x400000>;
+	};
+
+	partition@8a0000 {
+		label = "ubi";
+		reg = <0x540000 0x7a40000>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_zte_e8820s.dts
+++ b/target/linux/ramips/dts/mt7621_zte_e8820s.dts
@@ -1,211 +1,66 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7621_zte_e8820s.dtsi"
 
 / {
 	compatible = "zte,e8820s", "mediatek,mt7621-soc";
 	model = "ZTE E8820S";
-
-	aliases {
-		led-boot = &power_led;
-		led-failsafe = &system_led;
-		led-running = &system_led;
-		led-upgrade = &system_led;
-		label-mac-device = &gmac0;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
-
-	gpio-leds {
-		compatible = "gpio-leds";
-
-		power_led: led-power {
-			label = "white:power";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-		};
-
-		system_led: led-system {
-			label = "white:system";
-			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		button-reset {
-			label = "reset";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		button-wifi {
-			label = "wifi";
-			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RFKILL>;
-		};
-
-		button-wps {
-			label = "wps";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
 };
 
-&gmac0 {
-	nvmem-cells = <&macaddr_config_12 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	status = "okay";
-	label = "wan";
-	phy-handle = <&ethphy4>;
-
-	nvmem-cells = <&macaddr_config_12 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&mdio {
-	ethphy4: ethernet-phy@4 {
-		reg = <4>;
+&partitions {
+	partition@0 {
+		label = "Bootloader";
+		reg = <0x0 0x220000>;
+		read-only;
 	};
-};
 
-&nand {
-	status = "okay";
+	partition@80000 {
+		compatible = "nvmem-cells";
+		label = "config";
+		reg = <0x220000 0x140000>;
+		read-only;
 
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		partition@0 {
-			label = "Bootloader";
-			reg = <0x0 0x220000>;
-			read-only;
-		};
-
-		partition@80000 {
-			compatible = "nvmem-cells";
-			label = "config";
-			reg = <0x220000 0x140000>;
-			read-only;
-
-			nvmem-layout {
-				compatible = "fixed-layout";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_config_12: macaddr@12 {
-					compatible = "mac-base";
-					reg = <0x12 0x6>;
-					#nvmem-cell-cells = <1>;
-				};
+			macaddr_config_12: macaddr@12 {
+				compatible = "mac-base";
+				reg = <0x12 0x6>;
+				#nvmem-cell-cells = <1>;
 			};
 		};
+	};
 
-		factory: partition@360000 {
-			compatible = "nvmem-cells";
-			label = "factory";
-			reg = <0x360000 0x140000>;
-			read-only;
+	factory: partition@360000 {
+		compatible = "nvmem-cells";
+		label = "factory";
+		reg = <0x360000 0x140000>;
+		read-only;
 
-			nvmem-layout {
-				compatible = "fixed-layout";
-				#address-cells = <1>;
-				#size-cells = <1>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-				eeprom_factory_f000: eeprom@f000 {
-					reg = <0xf000 0x400>;
-				};
+			eeprom_factory_f000: eeprom@f000 {
+				reg = <0xf000 0x400>;
+			};
 
-				eeprom_factory_f800: eeprom@f800 {
-					reg = <0xf800 0x200>;
-				};
+			eeprom_factory_f800: eeprom@f800 {
+				reg = <0xf800 0x200>;
 			};
 		};
-
-		partition@4a0000 {
-			label = "kernel";
-			reg = <0x4a0000 0x400000>;
-		};
-
-		partition@8a0000 {
-			label = "ubi";
-			reg = <0x8a0000 0x76e0000>;
-		};
 	};
-};
 
-&pcie {
-	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
-		      <&gpio 4 GPIO_ACTIVE_LOW>;
-	status = "okay";
-};
-
-&pcie0 {
-	wifi@0,0 {
-		compatible = "pci14c3,7603";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_f000>, <&macaddr_config_12 0>;
-		nvmem-cell-names = "eeprom", "mac-address";
-		ieee80211-freq-limit = <2400000 2500000>;
-
-		led {
-			led-active-low;
-		};
+	partition@4a0000 {
+		label = "kernel";
+		reg = <0x4a0000 0x400000>;
 	};
-};
 
-&pcie1 {
-	wifi@0,0 {
-		compatible = "pci14c3,7662";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_f800>, <&macaddr_config_12 1>;
-		nvmem-cell-names = "eeprom", "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-
-		led {
-			led-active-low;
-			led-sources = <2>;
-		};
-	};
-};
-
-&switch0 {
-	ports {
-		port@0 {
-			status = "okay";
-			label = "lan1";
-		};
-
-		port@1 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan4";
-		};
-	};
-};
-
-&state_default {
-	gpio {
-		groups = "jtag", "uart2", "uart3", "wdt";
-		function = "gpio";
+	partition@8a0000 {
+		label = "ubi";
+		reg = <0x8a0000 0x76e0000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zte_e8820s.dtsi
+++ b/target/linux/ramips/dts/mt7621_zte_e8820s.dtsi
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &power_led;
+		led-failsafe = &system_led;
+		led-running = &system_led;
+		led-upgrade = &system_led;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_led: led-power {
+			label = "white:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		system_led: led-system {
+			label = "white:system";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wifi {
+			label = "wifi";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_config_12 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_config_12 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions: partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
+&pcie {
+	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+		      <&gpio 4 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_f000>, <&macaddr_config_12 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_f800>, <&macaddr_config_12 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+			led-sources = <2>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3078,6 +3078,13 @@ define Device/zte_e8820s
 endef
 TARGET_DEVICES += zte_e8820s
 
+define Device/zte_e8820s-breed
+  $(Device/zte_e8820s)
+  DEVICE_MODEL += (MTK SDK Partition)
+  IMAGE_SIZE := 129280k
+endef
+TARGET_DEVICES += zte_e8820s-breed
+
 define Device/zyxel_lte3301-plus
   $(Device/nand)
   DEVICE_VENDOR := ZyXEL

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -250,7 +250,8 @@ yuncore,ax820)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
-zte,e8820s)
+zte,e8820s|\
+zte,e8820s-breed)
 	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1-ap0"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -121,6 +121,7 @@ platform_do_upgrade() {
 	xiaomi,mi-router-cr6609|\
 	xiaomi,redmi-router-ac2100|\
 	zte,e8820s|\
+	zte,e8820s-breed|\
 	zyxel,nwa50ax|\
 	zyxel,nwa55axe)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
partition: 512k(u-boot),512k(u-boot-env),256k(factory),4096k(kernel),-(ubi).
flashing via breed, choose "sdk reference".