### PR TITLE
generic: fix kernel 6.1 FLOWOFFLOAD for iptables support

### DIFF
--- a/target/linux/generic/hack-6.1/650-netfilter-add-xt_FLOWOFFLOAD-target.patch
+++ b/target/linux/generic/hack-6.1/650-netfilter-add-xt_FLOWOFFLOAD-target.patch
@@ -8,7 +8,30 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
-@@ -1023,6 +1023,15 @@ config NETFILTER_XT_TARGET_NOTRACK
+@@ -712,8 +712,6 @@ config NFT_REJECT_NETDEV
+ 
+ endif # NF_TABLES_NETDEV
+ 
+-endif # NF_TABLES
+-
+ config NF_FLOW_TABLE_INET
+ 	tristate "Netfilter flow table mixed IPv4/IPv6 module"
+ 	depends on NF_FLOW_TABLE
+@@ -722,11 +720,12 @@ config NF_FLOW_TABLE_INET
+ 
+ 	  To compile it as a module, choose M here.
+ 
++endif # NF_TABLES
++
+ config NF_FLOW_TABLE
+ 	tristate "Netfilter flow table module"
+ 	depends on NETFILTER_INGRESS
+ 	depends on NF_CONNTRACK
+-	depends on NF_TABLES
+ 	help
+ 	  This option adds the flow table core infrastructure.
+ 
+@@ -1023,6 +1022,15 @@ config NETFILTER_XT_TARGET_NOTRACK
  	depends on NETFILTER_ADVANCED
  	select NETFILTER_XT_TARGET_CT
  
@@ -654,7 +677,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +};
 +
 +static int nf_flow_rule_route_inet(struct net *net,
-+				   const struct flow_offload *flow,
++				   struct flow_offload *flow,
 +				   enum flow_offload_tuple_dir dir,
 +				   struct nf_flow_rule *flow_rule)
 +{


### PR DESCRIPTION
`const` has been removed. ref:
https://elixir.bootlin.com/linux/v6.1.73/source/include/net/netfilter/nf_flow_table.h#L61
https://elixir.bootlin.com/linux/v6.1.73/source/include/net/netfilter/nf_flow_table.h#L328
https://elixir.bootlin.com/linux/v6.1.73/source/include/net/netfilter/nf_flow_table.h#L331