### PR TITLE
netifd： Update packet-steering.sh

### DIFF
--- a/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
+++ b/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
@@ -32,7 +32,7 @@ set_hex_val() {
 	echo "$val" > "$file"
 }
 
-packet_steering="$(uci get "network.@globals[0].packet_steering")"
+packet_steering="$(uci -q get "network.@globals[0].packet_steering")"
 [ "$packet_steering" != 1 ] && exit 0
 
 exec 512>/var/lock/smp_tune.lock


### PR DESCRIPTION
uci: Entry not found

![image](https://github.com/immortalwrt/immortalwrt/assets/45259624/bf7e5b9d-8f92-463d-a8ff-c1f33333da29)
