### PR TITLE
ipq40xx: refresh patches

### DIFF
--- a/target/linux/ipq40xx/patches-6.6/991-ipq40xx-unlock-cpu-frequency.patch
+++ b/target/linux/ipq40xx/patches-6.6/991-ipq40xx-unlock-cpu-frequency.patch
@@ -9,8 +9,8 @@ unlock 896Mhz CPU operating points.
 Signed-off-by: William <gw826943555@qq.com>
 ---
 
---- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
-+++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+--- a/arch/arm/boot/dts/qcom/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom/qcom-ipq4019.dtsi
 @@ -114,20 +114,24 @@
  
  		opp-48000000 {


### PR DESCRIPTION
the qcom-xxx.dtsi has moved to /qcom/ in kernel 6.6, therefore change the patch file path accordingly.

P.S. we'd better double check the line numbers before merge.