### PR TITLE
ramips: update Bolt BL201 to match stock bootloader

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
@@ -3,94 +3,120 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "bolt,bl201", "ralink,mt7620a-soc";
 	model = "Bolt BL201";
 
 	aliases {
-		led-boot = &power_red;
-		led-failsafe = &power_red;
-		led-running = &power_blue;
-		led-upgrade = &power_red;
+		led-boot = &led_reset;
+		led-failsafe = &led_reset;
+		led-running = &led_power;
+		led-upgrade = &led_reset;
 		label-mac-device = &ethernet;
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "console=ttyS0,57600";
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		wan {
-			function = LED_FUNCTION_WAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-		};
-
-		power_red: power_red {
-			function = LED_FUNCTION_POWER;
+		led_reset: led-reset {
+			function = LED_FUNCTION_BOOT;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
-		power_blue: power_blue {
+		led_power: led-power {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s1_blue {
-			label = "blue:lte_s1";
+		led-lte1 {
+			label = "blue:lte1";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s2_blue {
-			label = "blue:lte_s2";
+		led-lte2 {
+			label = "blue:lte2";
 			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s3_blue {
-			label = "blue:lte_s3";
+		led-lte3 {
+			label = "blue:lte3";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s4_blue {
-			label = "blue:lte_s4";
+		led-lte4 {
+			label = "blue:lte4";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
+		
+		led-lte5 {
+			label = "red:lte5";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
 
-		wps_blue {
+		led-lte6 {
+			label = "red:lte6";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wps {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s1s2_red {
-			label = "red:lte_s1s2";
-			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		led-voip {
+			label = "blue:voip";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s3s4_red {
-			label = "red:lte_s3s4";
-			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
-		};
-
-		wlan_blue {
-			function = LED_FUNCTION_WLAN;
+		led-wlan2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		led-wlan5 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+		
+		led-lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+		
+		led-wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 	};
 
 	keys {
 		compatible = "gpio-keys";
 
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
 		reset {
 			label = "reset";
-			gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -117,7 +143,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <70000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -163,9 +189,10 @@
 			};
 
 			partition@50000 {
-				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x26112015>;
 			};
 
 			partition@fd0000 {
@@ -205,8 +232,10 @@
 &wmac {
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
-	pinctrl-names = "default";
+	
+	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
 };
 
 &pcie {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -164,7 +164,8 @@ define Device/bolt_bl201
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Bolt
   DEVICE_MODEL := BL201
-  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+  UIMAGE_MAGIC := 0x26112015
 endef
 TARGET_DEVICES += bolt_bl201
 

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -40,14 +40,11 @@ asus,rt-n14u)
 bdcom,wap2100-sk)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
-bolt,bl100)
+bolt,bl100|\
+bolt,bl201)
 	ucidef_set_led_default "power" "power" "blue:power" "1"
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0.1"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth0.2"
-	;;
-bolt,bl201)
-	ucidef_set_led_netdev "phy0-ap0" "phy0-ap0" "blue:wlan" "phy0-ap0"
-	ucidef_set_led_netdev "wan" "eth0.2" "blue:wan" "eth0.2"
 	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1


### PR DESCRIPTION
### Comment:
No need to change the bootloader using breedweb anymore.
But breedweb can still be used.

### Changes:
1. Update device baudrate
2. Update some of leds and button gpios values and names
3. Update partition layout to match the stock layout
4. Update missing package depends for usb
5. Add device UIMAGE Magic value