### PR TITLE
rockchip: refresh patch

### DIFF
--- a/target/linux/rockchip/patches-6.6/034-15-v6.8-drm-nouveau-use-GPUVM-common-infrastructure.patch
+++ b/target/linux/rockchip/patches-6.6/034-15-v6.8-drm-nouveau-use-GPUVM-common-infrastructure.patch
@@ -338,7 +338,7 @@ Link: https://patchwork.freedesktop.org/patch/msgid/20231113221202.7203-1-dakr@r
  	list_for_each_op(op, &bind_job->ops) {
  		switch (op->op) {
  		case OP_MAP_SPARSE:
-@@ -1290,55 +1337,13 @@ nouveau_uvmm_bind_job_submit(struct nouv
+@@ -1290,57 +1339,13 @@ nouveau_uvmm_bind_job_submit(struct nouv
  		}
  	}
  
@@ -376,6 +376,7 @@ Link: https://patchwork.freedesktop.org/patch/msgid/20231113221202.7203-1-dakr@r
 -
 -		drm_gpuva_for_each_op(va_op, op->ops) {
 -			struct drm_gem_object *obj = op_gem_obj(va_op);
+-			struct nouveau_bo *nvbo;
 -
 -			if (unlikely(!obj))
 -				continue;
@@ -386,8 +387,9 @@ Link: https://patchwork.freedesktop.org/patch/msgid/20231113221202.7203-1-dakr@r
 -			if (unlikely(va_op->op == DRM_GPUVA_OP_UNMAP))
 -				continue;
 -
--			ret = nouveau_bo_validate(nouveau_gem_object(obj),
--						  true, false);
+-			nvbo = nouveau_gem_object(obj);
+-			nouveau_bo_placement_set(nvbo, nvbo->valid_domains, 0);
+-			ret = nouveau_bo_validate(nvbo, true, false);
 -			if (ret) {
 -				op = list_last_op(&bind_job->ops);
 -				goto unwind;


### PR DESCRIPTION
kernel 6.6.46 introduce a patch in the same file, details here: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.6.46&id=37e79836d6a4a79c85ee08aa3be6434463e8b0a2

so refresh this patch, and build tested OK here: https://github.com/xlighting2017/Actions-Openwrt/actions/runs/10518835096/job/29145240288