### PR TITLE
rockchip: fix rgb pinctrl duplicate names 

### DIFF
--- a/package/boot/uboot-rockchip/src/arch/arm/dts/rk3588-cyber3588-aib.dts
+++ b/package/boot/uboot-rockchip/src/arch/arm/dts/rk3588-cyber3588-aib.dts
@@ -508,15 +508,15 @@
 
 &pinctrl {
 	gpio-leds {
-		red_led_pin: status-led-pin {
+		red_led_pin: red-led-pin {
 			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
-		green_led_pin: status-led-pin {
+		green_led_pin: green-led-pin {
 			rockchip,pins = <1 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
-		blue_led_pin: status-led-pin {
+		blue_led_pin: blue-led-pin {
 			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};

--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts
@@ -541,15 +541,15 @@
 
 &pinctrl {
 	gpio-leds {
-		red_led_pin: status-led-pin {
+		red_led_pin: red-led-pin {
 			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
-		green_led_pin: status-led-pin {
+		green_led_pin: green-led-pin {
 			rockchip,pins = <1 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
-		blue_led_pin: status-led-pin {
+		blue_led_pin: blue-led-pin {
 			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};


### PR DESCRIPTION
the last commit https://github.com/immortalwrt/immortalwrt/commit/bff07d91b61cc3e14c91bcfca4076611eae26ad2 introduce error/duplicate_node_names in dts file:

```
arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts:548.33-550.5: ERROR (duplicate_node_names): /pinctrl/gpio-leds/status-led-pin: Duplicate node name
arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts:552.32-554.5: ERROR (duplicate_node_names): /pinctrl/gpio-leds/status-led-pin: Duplicate node name
arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts:552.32-554.5: ERROR (duplicate_node_names): /pinctrl/gpio-leds/status-led-pin: Duplicate node name
ERROR: Input tree has errors, aborting (use -f to force output)
make[8]: *** [scripts/Makefile.lib:423: arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dtb] Error 2
make[7]: *** [scripts/Makefile.build:480: arch/arm64/boot/dts/rockchip] Error 2
```

fix it via change the node names accordingly.