### PR TITLE
rockchip: add support for EZPRO Mrkaio M68S PLUS

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -230,15 +230,17 @@ define U-Boot/lyt-t68m-rk3568
 endef
 
 define U-Boot/mrkaio-m68s-rk3568
-  BUILD_SUBTARGET:=armv8
+  $(U-Boot/rk3568/Default)
   NAME:=Mrkaio M68S
   BUILD_DEVICES:= \
-    ezpro_mrkaio-m68s \
+    ezpro_mrkaio-m68s
+endef
+
+define U-Boot/mrkaio-m68s-plus-rk3568
+  $(U-Boot/rk3568/Default)
+  NAME:=Mrkaio M68S Plus
+  BUILD_DEVICES:= \
     ezpro_mrkaio-m68s-plus
-  DEPENDS:=+PACKAGE_u-boot-mrkaio-m68s-rk3568:arm-trusted-firmware-rk3568
-  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip-vendor
-  ATF:=rk3568_bl31_v1.28.elf
-  DDR:=rk3568_ddr_1560MHz_v1.13.bin
 endef
 
 define U-Boot/nanopi-r5c-rk3568

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -230,10 +230,15 @@ define U-Boot/lyt-t68m-rk3568
 endef
 
 define U-Boot/mrkaio-m68s-rk3568
-  $(U-Boot/rk3568/Default)
+  BUILD_SUBTARGET:=armv8
   NAME:=Mrkaio M68S
   BUILD_DEVICES:= \
-    ezpro_mrkaio-m68s
+    ezpro_mrkaio-m68s \
+    ezpro_mrkaio-m68s-plus
+  DEPENDS:=+PACKAGE_u-boot-mrkaio-m68s-rk3568:arm-trusted-firmware-rk3568
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip-vendor
+  ATF:=rk3568_bl31_v1.28.elf
+  DDR:=rk3568_ddr_1560MHz_v1.13.bin
 endef
 
 define U-Boot/nanopi-r5c-rk3568

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -401,6 +401,7 @@ UBOOT_TARGETS := \
   fastrhino-r68s-rk3568 \
   lyt-t68m-rk3568 \
   mrkaio-m68s-rk3568 \
+  mrkaio-m68s-plus-rk3568 \
   nanopi-r5c-rk3568 \
   nanopi-r5s-rk3568 \
   photonicat-rk3568 \

--- a/package/boot/uboot-rockchip/patches/900-arm-add-dts-files.patch
+++ b/package/boot/uboot-rockchip/patches/900-arm-add-dts-files.patch
@@ -12,6 +12,7 @@
 +	rk3568-armsom-sige3.dtb \
 +	rk3568-lyt-t68m.dtb \
 +	rk3568-mrkaio-m68s.dtb \
++	rk3568-mrkaio-m68s-plus.dtb \
 +	rk3568-photonicat.dtb
 +
 +dtb-$(CONFIG_ROCKCHIP_RK3588) += \

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ rockchip_setup_interfaces()
 	ariaboard,photonicat|\
 	armsom,sige7|\
 	ezpro,mrkaio-m68s|\
+        ezpro,mrkaio-m68s-plus|\
 	firefly,rk3568-roc-pc|\
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2c-plus|\
@@ -70,6 +71,7 @@ rockchip_setup_macs()
 	armsom,sige7|\
 	cyber,cyber3588-aib|\
 	ezpro,mrkaio-m68s|\
+        ezpro,mrkaio-m68s-plus|\
 	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2s|\

--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3568-mrkaio-m68s-plus.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3568-mrkaio-m68s-plus.dts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+// Copyright (c) 2023 mleaf <mleaf90@gmail.com>
+
+/dts-v1/;
+
+#include "rk3568-mrkaio-m68s.dtsi"
+
+/ {
+	model = "EZPRO Mrkaio M68S PLUS";
+	compatible = "ezpro,mrkaio-m68s-plus", "rockchip,rk3568";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_sys_en>;
+
+		led_sys: sys {
+			label = "red:sys";
+			gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	switch_otg: switch-otg {
+		compatible = "regulator-fixed";
+		gpio = <&gpio2 RK_PC6 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb_otg_switch_en>;
+		regulator-name = "switch_otg";
+		regulator-always-on;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		startup-delay-us = <5000>;
+		vin-supply = <&dc_12v>;
+	};
+};
+
+&pcie2x1 {
+	num-viewport = <4>;
+	reset-gpios = <&gpio2 RK_PB5 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		r8125_1: pcie@01,0 {
+			reg = <0x000000 0 0 0 0>;
+		};
+	};
+};
+
+&pcie30phy {
+	data-lanes = <1 2>;
+	status = "okay";
+};
+
+&pcie3x1 {
+	num-viewport = <4>;
+	reset-gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x00100000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		r8125_2: pcie@10,0 {
+			reg = <0x000000 0 0 0 0>;
+		};
+	};
+};
+
+&pcie3x2 {
+	num-lanes = <1>;
+	max-link-speed = <2>;
+	num-ib-windows = <8>;
+	num-ob-windows = <8>;
+	num-viewport = <4>;
+	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
+	status = "okay";
+};
+
+&pinctrl {
+	leds {
+		led_sys_en: led_sys_en {
+			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	usb {
+		vcc5v0_usb_host_en: vcc5v0_usb_host_en {
+			rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		vcc5v0_usb_otg_en: vcc5v0_usb_otg_en {
+			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+		
+		usb_otg_switch_en: usb-otg-switch_en {
+			rockchip,pins = <2 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -63,6 +63,16 @@ define Device/ezpro_mrkaio-m68s
 endef
 TARGET_DEVICES += ezpro_mrkaio-m68s
 
+define Device/ezpro_mrkaio-m68s-plus
+  DEVICE_VENDOR := EZPRO
+  DEVICE_MODEL := Mrkaio M68S PLUS
+  SOC := rk3568
+  UBOOT_DEVICE_NAME := mrkaio-m68s-rk3568
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r5s | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8125 kmod-ata-ahci kmod-ata-ahci-platform kmod-nvme kmod-scsi-core
+endef
+TARGET_DEVICES += ezpro_mrkaio-m68s-plus
+
 define Device/firefly_roc-rk3328-cc
   DEVICE_VENDOR := Firefly
   DEVICE_MODEL := ROC-RK3328-CC

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -69,7 +69,7 @@ define Device/ezpro_mrkaio-m68s-plus
   SOC := rk3568
   UBOOT_DEVICE_NAME := mrkaio-m68s-rk3568
   BOOT_FLOW := pine64-img
-  DEVICE_PACKAGES := kmod-r8125 kmod-ata-ahci kmod-ata-ahci-platform kmod-nvme kmod-scsi-core
+  DEVICE_PACKAGES := kmod-r8125
 endef
 TARGET_DEVICES += ezpro_mrkaio-m68s-plus
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -68,7 +68,7 @@ define Device/ezpro_mrkaio-m68s-plus
   DEVICE_MODEL := Mrkaio M68S PLUS
   SOC := rk3568
   UBOOT_DEVICE_NAME := mrkaio-m68s-rk3568
-  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r5s | pine64-img | gzip | append-metadata
+  BOOT_FLOW := pine64-img
   DEVICE_PACKAGES := kmod-r8125 kmod-ata-ahci kmod-ata-ahci-platform kmod-nvme kmod-scsi-core
 endef
 TARGET_DEVICES += ezpro_mrkaio-m68s-plus


### PR DESCRIPTION
rockchip: add support for EZPRO Mrkaio M68S PLUS
Specifications:

SoC: RK3568-B2
CPU: Quad-core Cortex-A55 up to 2.0GHz
NPU: 1TOPS NPU
RAM: 4GB
Storage: 32G EMMC
Ethernet: 2x 2.5G/1000/100/10 ports