### PR TITLE
autocore: use ubus to get cpu/arch info

### DIFF
--- a/package/emortal/autocore/files/cpuinfo
+++ b/package/emortal/autocore/files/cpuinfo
@@ -2,11 +2,10 @@
 
 . /etc/openwrt_release
 
-CPUINFO_PATH="/proc/cpuinfo"
 CPUFREQ_PATH="/sys/devices/system/cpu/cpufreq"
 THERMAL_PATH="/sys/class/thermal"
 
-cpu_arch="$(awk -F ': ' '/model name/ {print $2}' "$CPUINFO_PATH" | head -n1)"
+cpu_arch="$(ubus call system board | jsonfilter -q -e @.system)"
 [ -n "${cpu_arch}" ] || cpu_arch="?"
 
 case "$DISTRIB_TARGET" in


### PR DESCRIPTION
switch from `cat /proc/cpuinfo` to `ubus`

fixes: #1632