### PR TITLE
ath79: add support for ZTE E8820

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -64,6 +64,7 @@ yuncore,a782|\
 yuncore,a930|\
 yuncore,xd3200|\
 yuncore,xd4200|\
+zte,e8820|\
 zyxel,nbg6616)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ath79/dts/qca9563_zte_e8820.dts
+++ b/target/linux/ath79/dts/qca9563_zte_e8820.dts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	model = "ZTE E8820";
+	compatible = "zte,e8820", "qca,qca9563";
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_green;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		usb1 {
+			label = "zte:green:usb1";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb2 {
+			label = "zte:green:usb2";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		power_green: power_green {
+			label = "zte:green:power";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan5g_green {
+			label = "zte:green:wlan5g";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g_green {
+			label = "zte:green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	mtd-mac-address = <&art 0x0>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0xc>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -230,7 +230,8 @@ ath79_setup_interfaces()
 	sitecom,wlr-7100|\
 	tplink,archer-c2-v3|\
 	tplink,tl-wr1043nd-v4|\
-	tplink,tl-wr1043n-v5)
+	tplink,tl-wr1043n-v5|\
+	zte,e8820)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
@@ -664,6 +665,11 @@ ath79_setup_macs()
 		;;
 	xiaomi,aiot-ac2350)
 		lan_mac=$(mtd_get_mac_binary art 0x1002)
+ 		;;
+	zte,e8820)
+		wan_mac=$(mtd_get_mac_binary art 0)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	zyxel,nbg6616)
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -152,6 +152,10 @@ case "$FIRMWARE" in
 	tplink,tl-wpa8630-v1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x0fc00) +1)
+ 		;;
+	zte,e8820)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 3)
 		;;
 	esac
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2285,6 +2285,15 @@ define Device/zbtlink_zbt-wd323
 endef
 TARGET_DEVICES += zbtlink_zbt-wd323
 
+define Device/zte_e8820
+  SOC := qca9563
+  DEVICE_VENDOR := ZTE
+  DEVICE_MODEL := E8820
+  IMAGE_SIZE := 16000k
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += zte_e8820
+
 define Device/zyxel_nbg6616
   SOC := qca9557
   DEVICE_VENDOR := ZyXEL


### PR DESCRIPTION
-专门为国内用户适配，适配的是breed的0x50000启动地址非原厂uboot分区表
-硬件信息：
-QCA9563+AR8337+QCA9882
-RAM:64MB/128MB(ath10k默认smallbuffers节省内存）
-ROM:32MB（原厂分区表只用得到16MB，16MB后的分区表是test）
-手头设备无外置天线，无版本信息、标签就是:ZTE E8820，看帖子信息跟带外置天线的E8820V1以及E8821硬件几乎一致的除了 
 内存闪存天线外，其它一致。
https://github.com/coolsnowwolf/lede/commit/c2a9a0cfecc9180c09f8469dfea1980757bec053
Signed-off-by: Willem Lee <1980490718@qq.com>