### PR TITLE
ramips: add support for Hongdian H7920 v40

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
+++ b/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
@@ -1,0 +1,153 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hongdian,h7920-v40", "mediatek,mt7628an-soc";
+	model = "Hongdian H7920 v40";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			default-state = "on";
+		};
+
+		net {
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		rf {
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = "rf";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+
+		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <600>;
+		always-running;
+	};
+};
+
+&watchdog {
+	status = "disabled";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "refclk", "i2c", "i2s", "gpio", "spi cs1";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x3c>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -311,6 +311,15 @@ define Device/hiwifi_hc5861b
 endef
 TARGET_DEVICES += hiwifi_hc5861b
 
+define Device/hongdian_h7920-v40
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Hongdian
+  DEVICE_MODEL := H7920
+  DEVICE_VARIANT := v40
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += hongdian_h7920-v40
+
 define Device/iptime_a3
   IMAGE_SIZE := 7936k
   UIMAGE_NAME := a3

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -107,7 +107,8 @@ ramips_setup_interfaces()
 			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
 	duzun,dm06|\
-	glinet,gl-mt300n-v2)
+	glinet,gl-mt300n-v2|\
+	hongdian,h7920-v40)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -1,0 +1,17 @@
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+hongdian,h7920-v40)
+	ucidef_add_gpio_switch "modem_enable" "Enable LTE Modem" "516" "1"
+	ucidef_add_gpio_switch "switch_serial_mode" "Switch RS232 to RS485" "518" "0"
+	;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
This is an industrial 4G router equipped with OpenWrt SNAPSHOT OEM customized version

WARNING: The original firmware device tree is modified from evb boards, and the device tree name is evb board. This submitted device tree is a modified version, which deletes the non-this-device parts and adds GPIO watchdog.

Specification:
- SoC: MediaTek MT7628NN
- Flash: 16 MB
- RAM: 128 MB
- Power: DC 5V-36V 1.5A
- Ethernet: 1x WAN [slot not install], 1x LAN (10/100 Mbps)
- Wireless radio: 802.11n 2.4g-only [antenna not install]
- LED: System/Power (RUN): GPIO/37 active-low Modem: GPIO/3 active-low RF (Modem Signal): GPIO/2 active-low
- Button: WPS / RESET: GPIO/11 active-low
- UART: 1x UART on PCB - 115200 8N1
- Serial / COM: 1X RS232/RS485 on board (GPIO/6 hi:RS485 lo:RS232)
- GPIO Watchdog: GPIO/0 mode=toggle timeout=1s
- Modem: 1x Built-in modem on board (Power: GPIO/4 active-high)
- PCIe: 1x miniPCIe for modem [slot not install]
- SIM Slots: 1x SIM Slots

Issue:
- Factory partition not store mac address on original firmware

Flash instruction:
Using SSH/Telnet:
1. Connect the board to the computer via RJ45 Ethernet
2. Login 192.168.8.1 with root password "superzxmn" (SSH Port 22, Telnet Port 5188)
3. Download openwrt firmware on the computer.
4. Use scp or sftp put firmware to board /tmp
5. Use command "mtd -r write openwrt-ramips-mt76x8-hongdian_h7920-v40-squashfs-sysupgrade.bin firmware" to flash

Original Firmware Dump / More details:
https://blog.gov.cooking/archives/research-hongdian-h7920-v40-and-flash.html

---

Upstream PR is pending at http://github.com/openwrt/openwrt/pull/17726