### PR TITLE
default-settings: fix opkg_mirror behavior

### DIFF
--- a/package/emortal/default-settings/files/99-default-settings-chinese
+++ b/package/emortal/default-settings/files/99-default-settings-chinese
@@ -27,6 +27,8 @@ if [ -z "$opkg_mirror" ]; then
 	EOF
 fi
 
-sed -i.bak "s,https://downloads.immortalwrt.org,$opkg_mirror,g" "/etc/opkg/distfeeds.conf"
+sed -i.bak -e "s,https://downloads.immortalwrt.org,$opkg_mirror,g" \
+	   -e "s,https://mirrors.vsean.net/openwrt,$opkg_mirror,g" \
+	   "/etc/opkg/distfeeds.conf"
 
 exit 0


### PR DESCRIPTION
Currently when the default mirror is `https://mirrors.vsean.net/openwrt`, `system.@imm_init[0].opkg_mirror` doesn't work.

Change `sed` command to fix this problem.