### PR TITLE
rockchip: fix cyber3588 pwm fan.

### DIFF
--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3588-cyber3588-aib.dts
@@ -11,6 +11,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/pwm/pwm.h>
 #include <dt-bindings/usb/pd.h>
 #include "rk3588.dtsi"
 
@@ -58,9 +59,11 @@
 
 	fan: pwm-fan {
 		compatible = "pwm-fan";
-		cooling-levels = <0 50 80 120 160 220>;
-		fan-supply = <&vcc5v0_sys>;
-		pwms = <&pwm1 0 10000 0>;
+		cooling-levels = <0 72 117 162 229 255>;
+		fan-supply = <&vcc12v_dcin>;
+		interrupt-parent = <&gpio1>;
+		interrupts = <RK_PB7 IRQ_TYPE_EDGE_RISING>;
+		pwms = <&pwm1 0 10000 PWM_POLARITY_INVERTED>;
 		#cooling-cells = <2>;
 	};
 
@@ -469,6 +472,70 @@
 	};
 };
 
+&package_thermal {
+	polling-delay = <1000>;
+	polling-delay-passive = <2000>;
+
+	trips {
+		cpu_trip_active_cool: cpu-trip-active-cool {
+			temperature = <45000>;
+			hysteresis = <2000>;
+			type = "passive";
+		};
+
+		cpu_trip_active_low: cpu-trip-active-low {
+			temperature = <55000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_med: cpu-trip-active-med {
+			temperature = <65000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_high: cpu-trip-active-high {
+			temperature = <80000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_hot: cpu-trip-active-hot {
+			temperature = <90000>;
+			hysteresis = <2000>;
+			type = "hot";
+		};
+	};
+
+	cooling-maps {
+		cpu-active-cool {
+			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
+			trip = <&cpu_trip_active_cool>;
+		};
+
+		cpu-active-low {
+			cooling-device = <&fan 1 2>;
+			trip = <&cpu_trip_active_low>;
+		};
+
+		cpu-active-med {
+			cooling-device = <&fan 2 3>;
+			trip = <&cpu_trip_active_med>;
+		};
+
+		cpu-active-high {
+			cooling-device = <&fan 3 4>;
+			trip = <&cpu_trip_active_high>;
+		};
+
+		cpu-active-hot {
+			cooling-device = <&fan 4 THERMAL_NO_LIMIT>;
+			trip = <&cpu_trip_active_hot>;
+		};
+	};
+};
+
 /* M.2 M-Key */
 &pcie2x1l0 {
 	max-link-speed = <3>;
@@ -598,7 +665,7 @@
 };
 
 &pwm1 {
-	pinctrl-names = "active";
+	pinctrl-names = "default";
 	pinctrl-0 = <&pwm1m1_pins>;
 	status = "okay";
 };

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -50,7 +50,8 @@ define Device/cyber_cyber3588-aib
   SOC := rk3588
   BOOT_FLOW := pine64-img
   DEVICE_PACKAGES := kmod-ata-ahci-dwc kmod-r8125 kmod-mt7921e wpad-openssl \
-        kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+	kmod-hwmon-pwmfan kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += cyber_cyber3588-aib
 


### PR DESCRIPTION
Fixed property errors in DTS, enabling proper PWM loading. Additionally, added fan control based on package thermal temperature.

test result:
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# echo 45000 > emul_temp
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# cat /sys/class/hwmon/hwmon7/fan1_input
2666
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# echo 55000 > emul_temp
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# cat /sys/class/hwmon/hwmon7/fan1_input
3076
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# echo 75000 > emul_temp
root@ImmortalWrt:/sys/class/thermal/thermal_zone0# cat /sys/class/hwmon/hwmon7/fan1_input
4750