### PR TITLE
target/rockchip: drivers/rockchip-rng: fix -EPROBE_DEFER not propagat…

### DIFF
--- a/target/linux/rockchip/patches-6.6/801-06-rockchip-rng-fix-defer-probe.patch
+++ b/target/linux/rockchip/patches-6.6/801-06-rockchip-rng-fix-defer-probe.patch
@@ -1,0 +1,32 @@
+From 9c44338fcafc666150d2b931decb2239b14cad53 Mon Sep 17 00:00:00 2001
+From: jjm2473 <jjm2473@gmail.com>
+Date: Mon, 24 Mar 2025 18:57:58 +0800
+Subject: [PATCH] drivers/rockchip-rng: fix -EPROBE_DEFER not propagating
+ upwards
+
+kernel should retry probe later
+---
+ drivers/char/hw_random/rockchip-rng.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/char/hw_random/rockchip-rng.c b/drivers/char/hw_random/rockchip-rng.c
+index 47712631e..54e7268d5 100644
+--- a/drivers/char/hw_random/rockchip-rng.c
++++ b/drivers/char/hw_random/rockchip-rng.c
+@@ -503,10 +503,9 @@ static int rk_rng_probe(struct platform_device *pdev)
+ 		rk_rng->mem += rk_rng->soc_data->default_offset;
+ 
+ 	rk_rng->clk_num = devm_clk_bulk_get_all(&pdev->dev, &rk_rng->clk_bulks);
+-	if (rk_rng->clk_num < 0) {
+-		dev_err(&pdev->dev, "failed to get clks property\n");
+-		return -ENODEV;
+-	}
++	if (rk_rng->clk_num < 0)
++		return dev_err_probe(&pdev->dev, rk_rng->clk_num,
++				     "Failed to get clks property\n");
+ 
+ 	platform_set_drvdata(pdev, rk_rng);
+ 
+-- 
+2.46.0
+


### PR DESCRIPTION
…ing upwards


kernel should retry probe later

-----

注意，这个补丁是从istoreos的6.6内核补丁复制过来的，仅供参考，未在immortalwrt上refresh。

vendor的rockchip-rng驱动本身没啥大问题，只是linux现在启动时会同时probe多个驱动，而没有机制去解决驱动或设备之间的依赖问题，所以引入了PROBE_DEFER的机制，用来重试probe。rockchip-rng probe的时候，依赖的clk驱动还没完成probe，所以clk才获取失败，这只是因为clk还没准备好而已，错误码是-EPROBE_DEFER（-517），但是rockchip-rng又没将-EPROBE_DEFER向上传播到probe调用方，也就是内核框架，内核就以为这个驱动probe失败了，不再尝试。

这个补丁就是将-EPROBE_DEFER向上传播，dev_err_probe已经封装好了错误码的判断，无需自己实现。

PS：在6.6内核移植过程中，发现RK不少驱动都有-EPROBE_DEFER未向上传播的bug。甚至还有rk809未初始化导致开机时某些IO Domain未供电，相应的GPIO无法用的问题。