### PR TITLE
default-settings: fix script syntax

### DIFF
--- a/package/emortal/default-settings/files/99-default-settings
+++ b/package/emortal/default-settings/files/99-default-settings
@@ -33,6 +33,7 @@ case "$DISTRIB_TARGET" in
 		set system.@imm_init[0].packet_steering="1"
 		commit system
 	EOF
+	fi
 	;;
 esac
 


### PR DESCRIPTION
Fixed: condition syntax lost 'fi'