### PR TITLE
rockchip: refresh patches

### DIFF
--- a/target/linux/rockchip/patches-6.12/300-nvmem-rockchip-otp-Add-support-for-rk3568-otp.patch
+++ b/target/linux/rockchip/patches-6.12/300-nvmem-rockchip-otp-Add-support-for-rk3568-otp.patch
@@ -103,8 +103,8 @@ Change-Id: Ia74d77b68a6303223eaccdc08e882851a917f50f
  static int rk3588_otp_read(void *context, unsigned int offset,
  			   void *val, size_t bytes)
  {
-@@ -274,6 +343,17 @@ static const struct rockchip_data px30_d
- 	.reg_read = px30_otp_read,
+@@ -282,6 +351,17 @@ static const struct rockchip_data rk3576
+ 	.reg_read = rk3588_otp_read,
  };
  
 +static const char * const rk3568_otp_clocks[] = {
@@ -121,8 +121,8 @@ Change-Id: Ia74d77b68a6303223eaccdc08e882851a917f50f
  static const char * const rk3588_otp_clocks[] = {
  	"otp", "apb_pclk", "phy", "arb",
  };
-@@ -295,6 +375,10 @@ static const struct of_device_id rockchi
- 		.data = &px30_data,
+@@ -308,6 +388,10 @@ static const struct of_device_id rockchi
+ 		.data = &rk3576_data,
  	},
  	{
 +		.compatible = "rockchip,rk3568-otp",

--- a/target/linux/rockchip/patches-6.12/602-net-ethernet-r8169-add-devname-configuration-from-OF.patch
+++ b/target/linux/rockchip/patches-6.12/602-net-ethernet-r8169-add-devname-configuration-from-OF.patch
@@ -8,15 +8,15 @@
  #include <linux/tcp.h>
  #include <linux/interrupt.h>
  #include <linux/dma-mapping.h>
-@@ -5437,6 +5438,7 @@ static int rtl_init_one(struct pci_dev *
+@@ -5384,6 +5385,7 @@ static int rtl_init_one(struct pci_dev *
+ 	struct rtl8169_private *tp;
  	int jumbo_max, region, rc;
- 	enum mac_version chipset;
  	struct net_device *dev;
 +	const char *devname = of_get_property(pdev->dev.of_node, "label", NULL);
  	u32 txconfig;
  	u16 xid;
  
-@@ -5444,6 +5446,9 @@ static int rtl_init_one(struct pci_dev *
+@@ -5391,6 +5393,9 @@ static int rtl_init_one(struct pci_dev *
  	if (!dev)
  		return -ENOMEM;
  

--- a/target/linux/rockchip/patches-6.12/710-ethernet-stmicro-stmmac-Add-SGMII-QSGMII-support-for.patch
+++ b/target/linux/rockchip/patches-6.12/710-ethernet-stmicro-stmmac-Add-SGMII-QSGMII-support-for.patch
@@ -23,7 +23,7 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  #include <linux/of_net.h>
  #include <linux/module.h>
  #include <linux/of.h>
-@@ -28,6 +29,8 @@
+@@ -28,6 +29,8 @@ struct rk_gmac_ops {
  	void (*set_to_rgmii)(struct rk_priv_data *bsp_priv,
  			     int tx_delay, int rx_delay);
  	void (*set_to_rmii)(struct rk_priv_data *bsp_priv);
@@ -32,16 +32,16 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  	void (*set_rgmii_speed)(struct rk_priv_data *bsp_priv, int speed);
  	void (*set_rmii_speed)(struct rk_priv_data *bsp_priv, int speed);
  	void (*set_clock_selection)(struct rk_priv_data *bsp_priv, bool input,
-@@ -39,7 +42,7 @@
+@@ -39,7 +42,7 @@ struct rk_gmac_ops {
  };
-
+ 
  static const char * const rk_clocks[] = {
 -	"aclk_mac", "pclk_mac", "mac_clk_tx", "clk_mac_speed",
 +	"aclk_mac", "pclk_mac", "pclk_xpcs", "clk_xpcs_eee", "mac_clk_tx", "clk_mac_speed",
  };
-
+ 
  static const char * const rk_rmii_clocks[] = {
-@@ -49,6 +52,7 @@
+@@ -49,6 +52,7 @@ static const char * const rk_rmii_clocks
  enum rk_clocks_index {
  	RK_ACLK_MAC = 0,
  	RK_PCLK_MAC,
@@ -49,18 +49,18 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  	RK_MAC_CLK_TX,
  	RK_CLK_MAC_SPEED,
  	RK_MAC_CLK_RX,
-@@ -80,6 +84,7 @@
-
+@@ -80,6 +84,7 @@ struct rk_priv_data {
+ 
  	struct regmap *grf;
  	struct regmap *php_grf;
 +	struct regmap *xpcs;
  };
-
+ 
  #define HIWORD_UPDATE(val, mask, shift) \
-@@ -92,6 +97,128 @@
+@@ -92,6 +97,128 @@ struct rk_priv_data {
  	(((tx) ? soc##_GMAC_TXCLK_DLY_ENABLE : soc##_GMAC_TXCLK_DLY_DISABLE) | \
  	 ((rx) ? soc##_GMAC_RXCLK_DLY_ENABLE : soc##_GMAC_RXCLK_DLY_DISABLE))
-
+ 
 +/* XPCS */
 +#define XPCS_APB_INCREMENT		(0x4)
 +#define XPCS_APB_MASK			GENMASK_ULL(20, 0)
@@ -184,20 +184,20 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
 +}
 +
  #define PX30_GRF_GMAC_CON1		0x0904
-
+ 
  /* PX30_GRF_GMAC_CON1 */
-@@ -1020,6 +1147,7 @@
+@@ -1020,6 +1147,7 @@ static const struct rk_gmac_ops rk3399_o
  #define RK3568_GRF_GMAC1_CON1		0x038c
-
+ 
  /* RK3568_GRF_GMAC0_CON1 && RK3568_GRF_GMAC1_CON1 */
 +#define RK3568_GMAC_GMII_MODE			GRF_BIT(7)
  #define RK3568_GMAC_PHY_INTF_SEL_RGMII	\
  		(GRF_BIT(4) | GRF_CLR_BIT(5) | GRF_CLR_BIT(6))
  #define RK3568_GMAC_PHY_INTF_SEL_RMII	\
-@@ -1035,6 +1163,46 @@
+@@ -1035,6 +1163,46 @@ static const struct rk_gmac_ops rk3399_o
  #define RK3568_GMAC_CLK_RX_DL_CFG(val)	HIWORD_UPDATE(val, 0x7F, 8)
  #define RK3568_GMAC_CLK_TX_DL_CFG(val)	HIWORD_UPDATE(val, 0x7F, 0)
-
+ 
 +#define RK3568_PIPE_GRF_XPCS_CON0	0X0040
 +
 +#define RK3568_PIPE_GRF_XPCS_QGMII_MAC_SEL	GRF_BIT(0)
@@ -241,7 +241,7 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  static void rk3568_set_to_rgmii(struct rk_priv_data *bsp_priv,
  				int tx_delay, int rx_delay)
  {
-@@ -1107,6 +1275,8 @@
+@@ -1107,6 +1275,8 @@ static void rk3568_set_gmac_speed(struct
  static const struct rk_gmac_ops rk3568_ops = {
  	.set_to_rgmii = rk3568_set_to_rgmii,
  	.set_to_rmii = rk3568_set_to_rmii,
@@ -250,16 +250,16 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  	.set_rgmii_speed = rk3568_set_gmac_speed,
  	.set_rmii_speed = rk3568_set_gmac_speed,
  	.regs_valid = true,
-@@ -1736,7 +1906,7 @@
+@@ -1736,7 +1906,7 @@ static int gmac_clk_enable(struct rk_pri
  	return 0;
  }
-
+ 
 -static int phy_power_on(struct rk_priv_data *bsp_priv, bool enable)
 +static int rk_gmac_phy_power_on(struct rk_priv_data *bsp_priv, bool enable)
  {
  	struct regulator *ldo = bsp_priv->regulator;
  	int ret;
-@@ -1849,6 +2019,18 @@
+@@ -1849,6 +2019,18 @@ static struct rk_priv_data *rk_gmac_setu
  			return ERR_CAST(bsp_priv->php_grf);
  		}
  	}
@@ -275,10 +275,10 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
 +		if (ret)
 +			dev_err(dev, "phy_init error\n");
 +	}
-
+ 
  	if (plat->phy_node) {
  		bsp_priv->integrated_phy = of_property_read_bool(plat->phy_node,
-@@ -1926,11 +2108,19 @@
+@@ -1926,11 +2108,19 @@ static int rk_gmac_powerup(struct rk_pri
  		dev_info(dev, "init for RMII\n");
  		bsp_priv->ops->set_to_rmii(bsp_priv);
  		break;
@@ -293,22 +293,22 @@ Signed-off-by: David Wu <david.wu@rock-chips.com>
  	default:
  		dev_err(dev, "NO interface defined!\n");
  	}
-
+ 
 -	ret = phy_power_on(bsp_priv, true);
 +	ret = rk_gmac_phy_power_on(bsp_priv, true);
  	if (ret) {
  		gmac_clk_enable(bsp_priv, false);
  		return ret;
-@@ -1951,7 +2141,7 @@
-
+@@ -1951,7 +2141,7 @@ static void rk_gmac_powerdown(struct rk_
+ 
  	pm_runtime_put_sync(&gmac->pdev->dev);
-
+ 
 -	phy_power_on(gmac, false);
 +	rk_gmac_phy_power_on(gmac, false);
  	gmac_clk_enable(gmac, false);
  }
-
-@@ -1972,6 +2162,9 @@
+ 
+@@ -1972,6 +2162,9 @@ static void rk_fix_speed(void *priv, uns
  		if (bsp_priv->ops->set_rmii_speed)
  			bsp_priv->ops->set_rmii_speed(bsp_priv, speed);
  		break;


### PR DESCRIPTION
the kernel 6.12.31 make changes in dwmac-rk.c 

so a refresh is needed, otherwise it will fail:

```
Applying /mnt/workdir/openwrt/target/linux/rockchip/patches-6.12/710-ethernet-stmicro-stmmac-Add-SGMII-QSGMII-support-for.patch using plaintext: 
patching file drivers/net/ethernet/stmicro/stmmac/dwmac-rk.c
Hunk #3 succeeded at 42 (offset 1 line).
Hunk #4 succeeded at 52 (offset 1 line).
Hunk #5 succeeded at 84 (offset 1 line).
Hunk #6 succeeded at 97 (offset 1 line).
Hunk #7 succeeded at 1147 (offset 1 line).
Hunk #8 succeeded at 1163 (offset 1 line).
Hunk #9 succeeded at 1275 (offset 1 line).
Hunk #10 succeeded at 1906 (offset 3 lines).
Hunk #11 FAILED at 2002.
Hunk #12 succeeded at 2096 (offset 17 lines).
Hunk #13 succeeded at 2129 (offset 17 lines).
Hunk #14 succeeded at 2150 (offset 17 lines).
1 out of 14 hunks FAILED -- saving rejects to file drivers/net/ethernet/stmicro/stmmac/dwmac-rk.c.rej
Patch failed!  Please fix /mnt/workdir/openwrt/target/linux/rockchip/patches-6.12/710-ethernet-stmicro-stmmac-Add-SGMII-QSGMII-support-for.patch!
make[4]: *** [Makefile:33: /mnt/workdir/openwrt/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/linux-6.12.31/.prepared_4f944d75f52af56fb05d80d3c8b0a8d0] Error 1
make[4]: Leaving directory '/mnt/workdir/openwrt/target/linux/rockchip'
make[3]: *** [Makefile:12: compile] Error 2
```
ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/net/ethernet/stmicro/stmmac/dwmac-rk.c?h=v6.12.31&id=f933879c5b6a64ca0f5b4a68f0ea8b76c295d6d5