### PR TITLE
mediatek: Ruijie RG-X60 Pro: Fix WAN port status LED

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -105,6 +105,8 @@
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		realtek,aldps-enable;
+		realtek,led-link-select = <0xa7 0x00 0x0>; /* led0 at 10/100/1000/2.5G/(2.5G lite)*/
+		realtek,led-act-select = <0x001b>;
 	};
 };
 


### PR DESCRIPTION
Fix the status indicator light of the WAN port.
修复wan口状态灯