### PR TITLE
ath10k_sdio: load module manual

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -309,7 +309,7 @@ define KernelPackage/ath10k-sdio
   FILES:= \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_core.ko \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_sdio.ko
-  AUTOLOAD:=$(call AutoProbe,ath10k_core ath10k_sdio)
+  AUTOLOAD:=$(call AutoProbe,ath10k_core)
   MODPARAMS.ath10k_core:=frame_mode=2
   VARIANT:=sdio
 endef

--- a/target/linux/rockchip/armv8/base-files/etc/init.d/reload-sdio-wifi
+++ b/target/linux/rockchip/armv8/base-files/etc/init.d/reload-sdio-wifi
@@ -5,7 +5,7 @@ START=99
 boot() {
 	case "$(board_name)" in
 	ariaboard,photonicat)
-		( sleep 15s; wifi; ) &
+		( modprobe ath10k_sdio; sleep 5s; wifi config; wifi; ) &
 		;;
 	armsom,sige3)
 		( sleep 50s; wifi; ) &


### PR DESCRIPTION
The ath10k_sdio driver is no longer automatically loaded, which can cause `could not probe fw (-22)` errors.

Manually reload the driver after the system has finished loading using /etc/init.d/reload-sdio-wifi to resolve this issue.

Note: Do not use the automatic channel, as this may cause WiFi to not start.