### PR TITLE
mediatek: dts: fix syntax error (mismatched brace '{')

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dtsi
@@ -21,7 +21,7 @@
 		stdout-path = "serial0:115200n8";
 	};
 
-	memory@40000000
+	memory@40000000 {
 		reg = <0 0x40000000 0 0x10000000>;
 		device_type = "memory";
 	};


### PR DESCRIPTION
dts: fix missing opening brace