### PR TITLE
arm-trusted-firmware-mediatek: add MT7988 BL2 DDR3 RAM image

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -464,6 +464,17 @@ define Trusted-Firmware-A/mt7988-ram-comb
   DEFAULT:=TARGET_mediatek_filogic
 endef
 
+define Trusted-Firmware-A/mt7988-ram-ddr3
+  NAME:=MediaTek MT7988 (RAM/ddr3)
+  BOOT_DEVICE:=ram
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7988
+  RAM_BOOT_UART_DL:=1
+  HIDDEN:=
+  DEFAULT:=TARGET_mediatek_filogic
+  DDR_TYPE:=ddr3
+endef
+
 define Trusted-Firmware-A/mt7988-ram-ddr4
   NAME:=MediaTek MT7988 (RAM/ddr4)
   BOOT_DEVICE:=ram
@@ -593,6 +604,7 @@ TFA_TARGETS:= \
 	mt7988-snand-ddr4 \
 	mt7988-spim-nand-ddr4 \
 	mt7988-ram-comb \
+	mt7988-ram-ddr3 \
 	mt7988-ram-ddr4 \
 	mt7988-emmc-comb \
 	mt7988-nor-comb \
@@ -631,6 +643,7 @@ Package/trusted-firmware-a-mt7981-ram-ddr4/install = $(Package/trusted-firmware-
 Package/trusted-firmware-a-mt7986-ram-ddr3/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7986-ram-ddr4/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7988-ram-comb/install = $(Package/trusted-firmware-a-ram/install)
+Package/trusted-firmware-a-mt7988-ram-ddr3/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7988-ram-ddr4/install = $(Package/trusted-firmware-a-ram/install)
 
 define Package/trusted-firmware-a/install


### PR DESCRIPTION
Other than most boards with DDR3 the TP-Link 7DR7230 v2 cannot use the "comb" DDR calibration option and needs only the "ddr3" option set instead.

Build TF-A to boot with mtk_uartboot for MT7988 with DDR3 RAM.