### PR TITLE
ax3600: add OpenClash support to default config

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -6,3 +6,4 @@ src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed
+src-git openclash https://github.com/vernesong/OpenClash.git


### PR DESCRIPTION
Add OpenClash to default AX3600 config for easier use with Clash-based proxies.
