### PR TITLE
openwrt-keyring: fix usign key install path

### DIFF
--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -40,7 +40,7 @@ else
 define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
 	# Public usign key for 25.12 release builds
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/467a35c14d7fbc5c$(1)/etc/opkg/keys/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/467a35c14d7fbc5c $(1)/etc/opkg/keys/
 endef
 endif
 


### PR DESCRIPTION
Fix a missing space in the opkg usign key install rule.

The source and destination paths were concatenated, which caused the usign public key to fail to install during package installation.