### PR TITLE
rockchip: mod NLnet XiGuaPi V3 DEVICE_PACKAGES

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -334,7 +334,7 @@ define Device/nlnet_xiguapi-v3
   $(Device/rk3568)
   DEVICE_VENDOR := NLnet
   DEVICE_MODEL := XiGuaPi V3
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-input-adc-keys kmod-saradc-rockchip
 endef
 TARGET_DEVICES += nlnet_xiguapi-v3
 


### PR DESCRIPTION
Add ADC reset button support for NLnet XiGuaPi V3 by including required kernel modules:
- `kmod-input-adc-keys`: ADC-based input key support
- `kmod-saradc-rockchip`: Rockchip SARADC driver

The reset button on this device uses ADC instead of GPIO, requiring these modules for proper functionality.