### PR TITLE
add support for FudanMicro FM25G02B

### DIFF
--- a/target/linux/generic/hack-6.12/400-mtd-spinand-Support-fmsh.patch
+++ b/target/linux/generic/hack-6.12/400-mtd-spinand-Support-fmsh.patch
@@ -135,6 +135,7 @@ Signed-off-by: Jon Lin <jon.lin@rock-chips.com>
 +{
 +	if (section >= 8)
 +		return -ERANGE;
++
 +	region->offset = 64 + section * 8;
 +	region->length = 8;
 +
@@ -146,6 +147,7 @@ Signed-off-by: Jon Lin <jon.lin@rock-chips.com>
 +{
 +	if (section)
 +		return -ERANGE;
++
 +	region->offset = 2;
 +	region->length = 62;
 +


### PR DESCRIPTION
depend on target\linux\generic\backport-6.12
401-01-v6.18-mtd-spinand-add-support-for-FudanMicro-FM25S01A.patch

Machine model: Nokia Bell XG-040G-MD
