### PR TITLE
photonicat-pm: handle pmu shutdown request

### DIFF
--- a/package/kernel/photonicat-pm/Makefile
+++ b/package/kernel/photonicat-pm/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=photonicat-pm
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/package/kernel/photonicat-pm/src/photonicat-pm.c
+++ b/package/kernel/photonicat-pm/src/photonicat-pm.c
@@ -558,6 +558,10 @@ static void pcat_pm_uart_cmd_exec(struct pcat_pm_data *pm_data,
 		pm_data->poweroff_ok = true;
 		need_ack = false;
 		break;
+	case PCAT_PM_COMMAND_PMU_REQUEST_SHUTDOWN:
+		dev_info(&pm_data->serdev->dev, "PMU request shutdown.");
+		orderly_poweroff(true);
+		break;
 	case PCAT_PM_COMMAND_STATUS_REPORT:
 		pcat_pm_status_report_parse(
 			pm_data, extra_data, extra_data_len);
@@ -1209,6 +1213,10 @@ static void pcat_pm_ctl_cmd_exec(struct pcat_pm_data *pm_data,
 	case PCAT_PM_COMMAND_HOST_REQUEST_SHUTDOWN:
 		break;
 	case PCAT_PM_COMMAND_HOST_REQUEST_SHUTDOWN_ACK:
+		break;
+	case PCAT_PM_COMMAND_PMU_REQUEST_SHUTDOWN:
+		break;
+	case PCAT_PM_COMMAND_PMU_REQUEST_SHUTDOWN_ACK:
 		break;
 	case PCAT_PM_COMMAND_WATCHDOG_TIMEOUT_SET:
 		break;


### PR DESCRIPTION
The current version of the photonicat-pm ignore shutdown request (e.g. hold power button / low power) from pmu. Causing the pmu to cut off the system’s power after timeout.

This patch allow driver handle this request properly and poweroff system safely.

reference: https://github.com/photonicat/rockchip_rk3568_pcat_manager/blob/master/src/pmu-manager.c#L816