### PR TITLE
Fix the OF node of Ethernet in Rockchip DTS

### DIFF
--- a/target/linux/rockchip/patches-6.18/610-arm64-rockchip-add-OF-node-for-eth.patch
+++ b/target/linux/rockchip/patches-6.18/610-arm64-rockchip-add-OF-node-for-eth.patch
@@ -158,9 +158,9 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  	};
  };
  
-@@ -314,6 +333,18 @@
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&pwm1m0_pins>;
+@@ -268,6 +287,18 @@
+ 	reset-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc_3v3>;
  	status = "okay";
 +
 +	pcie@0,0 {
@@ -176,7 +176,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	};
  };
  
- &pwm2 {
+ &pinctrl {
 --- a/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3566-nanopi-r3s.dts
 @@ -417,6 +417,25 @@


### PR DESCRIPTION
DTC     arch/arm64/boot/dts/rockchip/rk3528-rock-2a.dtb
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dts:338.3-28: Warning (reg_format): /soc/pwm@ffa90010/pcie@0,0:reg: property has invalid length (20 bytes) (#address-cells == 2, #size-cells == 1)
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dtb: Warning (pci_device_reg): Failed prerequisite 'reg_format'
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dtb: Warning (pci_device_bus_num): Failed prerequisite 'reg_format'
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dtb: Warning (i2c_bus_reg): Failed prerequisite 'reg_format'
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dtb: Warning (spi_bus_reg): Failed prerequisite 'reg_format'
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dts:337.11-347.4: Warning (avoid_default_addr_size): /soc/pwm@ffa90010/pcie@0,0: Relying on default #address-cells value
arch/arm64/boot/dts/rockchip/rk3528-radxa-e20c.dts:337.11-347.4: Warning (avoid_default_addr_size): /soc/pwm@ffa90010/pcie@0,0: Relying on default #size-cells value