### PR TITLE
Fix quirk flag

### DIFF
--- a/target/linux/rockchip/patches-6.18/501-mmc-Add-MMC_QUIRK_BROKEN_ROCR_S18A-for-rtl8822cs.patch
+++ b/target/linux/rockchip/patches-6.18/501-mmc-Add-MMC_QUIRK_BROKEN_ROCR_S18A-for-rtl8822cs.patch
@@ -50,11 +50,11 @@ Signed-off-by: Jensen Huang <jensenhuang@friendlyarm.com>
  	 * to switch to 1.8V signaling level.  No 1.8v signalling if
 --- a/include/linux/mmc/card.h
 +++ b/include/linux/mmc/card.h
-@@ -330,6 +330,7 @@ struct mmc_card {
- #define MMC_QUIRK_BROKEN_CACHE_FLUSH	(1<<16)	/* Don't flush cache until the write has occurred */
- #define MMC_QUIRK_BROKEN_SD_POWEROFF_NOTIFY	(1<<17) /* Disable broken SD poweroff notify support */
+@@ -332,6 +332,7 @@ struct mmc_card {
  #define MMC_QUIRK_NO_UHS_DDR50_TUNING	(1<<18) /* Disable DDR50 tuning */
-+#define MMC_QUIRK_BROKEN_ROCR_S18A	(1<<19)	/* Disable broken S18A (1) in the R4 response */
+ #define MMC_QUIRK_BROKEN_MDT    (1<<19) /* Wrong manufacturing year */
+ #define MMC_QUIRK_FIXED_SECURE_ERASE_TRIM_TIME	(1<<20) /* Secure erase/trim time is fixed regardless of size */
++#define MMC_QUIRK_BROKEN_ROCR_S18A	(1<<21)	/* Disable broken S18A (1) in the R4 response */
  
  	bool			written_flag;	/* Indicates eMMC has been written since power on */
  	bool			reenable_cmdq;	/* Re-enable Command Queue */

--- a/target/linux/rockchip/patches-6.18/501-mmc-Add-MMC_QUIRK_BROKEN_ROCR_S18A-for-rtl8822cs.patch
+++ b/target/linux/rockchip/patches-6.18/501-mmc-Add-MMC_QUIRK_BROKEN_ROCR_S18A-for-rtl8822cs.patch
@@ -13,8 +13,8 @@ Signed-off-by: Jensen Huang <jensenhuang@friendlyarm.com>
 
 --- a/drivers/mmc/core/card.h
 +++ b/drivers/mmc/core/card.h
-@@ -305,4 +305,9 @@ static inline int mmc_card_no_uhs_ddr50_
- 	return c->quirks & MMC_QUIRK_NO_UHS_DDR50_TUNING;
+@@ -316,4 +316,9 @@ static inline int mmc_card_no_uhs_ddr50_
+ 	return c->quirks & MMC_QUIRK_FIXED_SECURE_ERASE_TRIM_TIME;
  }
  
 +static inline int mmc_card_broken_rocr_s18a(const struct mmc_card *c)
@@ -25,7 +25,7 @@ Signed-off-by: Jensen Huang <jensenhuang@friendlyarm.com>
  #endif
 --- a/drivers/mmc/core/quirks.h
 +++ b/drivers/mmc/core/quirks.h
-@@ -207,6 +207,9 @@ static const struct mmc_fixup __maybe_un
+@@ -219,6 +219,9 @@ static const struct mmc_fixup __maybe_un
  			      MMC_QUIRK_LENIENT_FN0 |
  			      MMC_QUIRK_BLKSZ_FOR_BYTE_MODE),
  


### PR DESCRIPTION
1 out of 1 hunk FAILED -- saving rejects to file include/linux/mmc/card.h.rej [1814](https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1815) (https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1815)Patch failed! Please fix /builder/openwrt/target/linux/rockchip/patches-6.18/501-mmc-Add-MMC_QUIRK_BROKEN_ROCR_S18A-for-rtl8822cs.patch! [1815](https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1816) (https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1816)make[4]: *** [Makefile:34: /builder/openwrt/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/linux-6.18.31/.prepared_009f8970d6031fb10157d35974ab10c0] Error 1 [1816](https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1817) (https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:[1817](https://github.com/lwb1978/OpenWrt-Actions/actions/runs/26169775703/job/76983914924#step:13:1818))make[4]: Leaving directory '/builder/openwrt/target/linux/rockchip'