### PR TITLE
aic8800: add USB mode-switch support for 1111:1111 storage-mode devices

### DIFF
--- a/package/kernel/aic8800/Makefile
+++ b/package/kernel/aic8800/Makefile
@@ -70,11 +70,16 @@ endef
 
 define KernelPackage/aic8800-usb
   $(call KernelPackage/aic8800/Default,USB)
-  DEPENDS+= +aic8800-usb-firmware +kmod-usb-core
+  DEPENDS+= +aic8800-usb-firmware +kmod-usb-core +usb-modeswitch
   FILES:= \
 	$(PKG_BUILD_DIR)/src/USB/driver_fw/drivers/aic8800/aic_load_fw/aic_load_fw.ko \
 	$(PKG_BUILD_DIR)/src/USB/driver_fw/drivers/aic8800/aic8800_fdrv/aic8800DC_fdrv.ko
   AUTOLOAD:=$(call AutoProbe,aic_load_fw aic8800DC_fdrv)
+endef
+
+define KernelPackage/aic8800-usb/install
+	$(INSTALL_DIR) $(1)/etc/usb_modeswitch.d
+	$(INSTALL_DATA) ./usb-modeswitch/1111:1111 $(1)/etc/usb_modeswitch.d/
 endef
 
 NOSTDINC_FLAGS:= \

--- a/package/kernel/aic8800/usb-modeswitch/1111:1111
+++ b/package/kernel/aic8800/usb-modeswitch/1111:1111
@@ -1,0 +1,12 @@
+# AIC8800D80/D81/DC USB WiFi adapter mode switch
+# Switches from storage mode (1111:1111) to WiFi mode (a69c:8d80/8d81)
+# Based on research by ademasi/aic8800d80-wifi-bt-linux
+
+DefaultVendor=0x1111
+DefaultProduct=0x1111
+TargetVendor=0xa69c
+TargetProductList="8800,8801,8d80,8d81"
+
+MessageContent="555342430000000000000000800010fd0000000000000000000000000000f3"
+MessageContent2="555342430000000000000000800010fd0000000000000000000000000000f2"
+NoDriverLoading=1

--- a/package/utils/usbmode/data/1111-1111
+++ b/package/utils/usbmode/data/1111-1111
@@ -1,0 +1,12 @@
+# AIC8800D80/D81/DC USB WiFi adapter — mode switch from storage to WiFi mode
+# Switches from 1111:1111 (virtual CD-ROM) to a69c:8d80/8d81 (WiFi)
+# Based on reverse engineering by ademasi/aic8800d80-wifi-bt-linux
+
+DefaultVendor=0x1111
+DefaultProduct=0x1111
+TargetVendor=0xa69c
+TargetProductList="8800,8801,8d80,8d81"
+
+MessageContent="555342430000000000000000800010fd0000000000000000000000000000f3"
+MessageContent2="555342430000000000000000800010fd0000000000000000000000000000f2"
+NoDriverLoading=1


### PR DESCRIPTION
Add usb_modeswitch configuration to switch AIC8800-based USB WiFi adapters (1111:1111) from USB Mass Storage mode to WiFi mode (a69c:8d80/8d81). The device requires two vendor-specific SCSI commands (GetHippo 0xF3 + Set_CS1_0 0xF2) sent as CBW wrappers.

- Add 1111:1111 config to usbmode data (package/utils/usbmode/data)
- Add usb_modeswitch.d config file to aic8800 kernel package
- Add usb-modeswitch dependency to kmod-aic8800-usb

Tested on AIC8800D81-based adapters with OpenWrt/ImmortalWrt 25.12 and Debian 13.

Based on research by ademasi/aic8800d80-wifi-bt-linux