### PR TITLE
mediatek: add support for CLX S20L router

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-clx-s20l.dts
+++ b/target/linux/mediatek/dts/mt7986a-clx-s20l.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7986a-clx-s20l.dtsi"
+
+/ {
+    model = "CLX S20L";
+    compatible = "clx,s20l", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &blue;
+		led-failsafe = &blue;
+		led-running = &blue;
+		led-upgrade = &blue;
+	};
+
+  gpio-leds {
+    compatible = "gpio-leds";
+
+    wlan2g_led: wlan2g-led {
+      function = "wlan-2ghz";
+      color = <LED_COLOR_ID_BLUE>;
+      gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_led: wlan5g-led {
+			function = "wlan-5ghz";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+      blue: status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7986a-clx-s20l.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-clx-s20l.dtsi
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "dm-mod.create=\"acer,,,ro,0 1 zero 1 0 0 0\" rootfstype=squashfs,ext4 rootwait root=/dev/mmcblk0p5 fstools_ignore_partname=1";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x80000000>;
+		device_type = "memory";
+	};
+
+  reg_1p8v: regulator-1p8v {
+    compatible = "regulator-fixed";
+    regulator-name = "fixed-1.8V";
+    regulator-min-microvolt = <1800000>;
+    regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+  
+		gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins {
+		mux {
+			function = "emmc";
+			groups = "emmc_51";
+		};
+
+		conf-cmd-dat {
+			pins = "EMMC_DATA_0", "EMMC_DATA_1", "EMMC_DATA_2",
+			       "EMMC_DATA_3", "EMMC_DATA_4", "EMMC_DATA_5",
+			       "EMMC_DATA_6", "EMMC_DATA_7", "EMMC_CMD";
+			input-enable;
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;	/* pull-up 10K */
+		};
+
+		conf-clk {
+			pins = "EMMC_CK";
+			drive-strength = <MTK_DRIVE_6mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;	/* pull-down 50K */
+		};
+
+		conf-ds {
+			pins = "EMMC_DSL";
+			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;	/* pull-down 50K */
+		};
+
+		conf-rst {
+			pins = "EMMC_RSTB";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;	/* pull-up 10K */
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-uhs-pins {
+		mux {
+			function = "emmc";
+			groups = "emmc_51";
+		};
+
+		conf-cmd-dat {
+			pins = "EMMC_DATA_0", "EMMC_DATA_1", "EMMC_DATA_2",
+			       "EMMC_DATA_3", "EMMC_DATA_4", "EMMC_DATA_5",
+			       "EMMC_DATA_6", "EMMC_DATA_7", "EMMC_CMD";
+			input-enable;
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;	/* pull-up 10K */
+		};
+
+		conf-clk {
+			pins = "EMMC_CK";
+			drive-strength = <MTK_DRIVE_6mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;	/* pull-down 50K */
+		};
+
+		conf-ds {
+			pins = "EMMC_DSL";
+			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;	/* pull-down 50K */
+		};
+
+		conf-rst {
+			pins = "EMMC_RSTB";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;	/* pull-up 10K */
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset";
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	wf_dbdc_pins: wf-dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	i2c_pins: i2c-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c";
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+	status = "okay";
+};
+
+&mmc0 {
+	status = "okay";
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <0x08>;
+	max-frequency = <200000000>;
+	cap-mmc-highspeed;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	hs400-ds-delay = <0x14014>;
+	vmmc-supply = <&reg_3p3v>;
+	vqmmc-supply = <&reg_1p8v>;
+	non-removable;
+	no-sd;
+	no-sdio;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem: nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_5: macaddr@5 {
+							compatible = "mac-base";
+							reg = <0x5 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+
+						macaddr_factory_24: macaddr@24 {
+							compatible = "mac-base";
+							reg = <0x24 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+
+						macaddr_factory_2a: macaddr@2a {
+							compatible = "mac-base";
+							reg = <0x2a 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+
+						macaddr_factory_30: macaddr@30 {
+							compatible = "mac-base";
+							reg = <0x30 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+  status = "okay";
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+ 
+		gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_2a 0>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+						ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "wan";
+					nvmem-cells = <&macaddr_factory_24 0>;
+					nvmem-cell-names = "mac-address";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan4";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan2";
+				};
+
+				port@4 {
+					reg = <4>;
+					label = "lan1";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+  #address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_5 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_30 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -308,6 +308,22 @@ define Device/asiarf_ap7986-003
 endef
 TARGET_DEVICES += asiarf_ap7986-003
 
+define Device/clx_s20l
+  DEVICE_VENDOR := CLX
+  DEVICE_MODEL := S20L
+  DEVICE_DTS := mt7986a-clx-s20l
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware kmod-mt7916-firmware \
+	mt7986-wo-firmware f2fsck mkf2fs automount
+  IMAGES := sysupgrade.bin
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += clx_s20l
+
 define Device/adtran_smartrg
   DEVICE_VENDOR := Adtran
   DEVICE_DTS_DIR := ../dts


### PR DESCRIPTION
## Device: CLX S20L

### Description
CLX S20L is a Chinese Wi-Fi 6 router based on the MediaTek MT7986A (Filogic 830) reference design. It features a 128GB eMMC storage, 2GB RAM, and a MediaTek MT7531 switch providing 4x 1Gbps LAN ports and 1x 1Gbps WAN port.

### Hardware Specifications
- **SoC:** MediaTek MT7986A (Filogic 830) Quad-core Cortex-A53 @ 2.0GHz
- **RAM:** 2GB DDR4
- **Storage:** 128GB eMMC (Samsung SDS7D2)
- **Wi-Fi:** 
  - 2.4GHz: 802.11b/g/n/ax, 2x2 MIMO (built-in MT7986)
  - 5GHz: 802.11a/n/ac/ax, 2x2 MIMO (built-in MT7986)
- **Ethernet:**
  - 4x 1Gbps LAN ports
  - 1x 1Gbps WAN port
  - Switch: MediaTek MT7531
- **USB:** 1x USB 3.0 port
- **LEDs:** 4x blue (status, wlan-2ghz, wlan-5ghz, pwr)
- **Buttons:** 1x reset button
- **Power:** 12V DC

### Installation

The device uses a custom GPT partition layout from the vendor firmware. Installation requires access to the U-Boot console (via vendor's web-based UART-over-IP interface or physical UART).

**Partition layout:**
| Partition | Name | Size | Purpose |
|-----------|------|------|---------|
| mmcblk0p1 | u-boot-env | 512KB | U-Boot environment |
| mmcblk0p2 | factory | 2MB | MAC addresses, EEPROM |
| mmcblk0p3 | fip | 2MB | ARM Trusted Firmware |
| mmcblk0p4 | kernel | 33MB | FIT kernel image |
| mmcblk0p5 | rootfs | 2GB | SquashFS root filesystem |
| mmcblk0p6 | storage | ~116GB | Ext4 user data (overlay) |

**Steps:**

1. Load ImmortalWRT initramfs image via U-Boot TFTP:
   ```
   tftpboot 0x46000000 immortalwrt-mediatek-filogic-clx_s20l-initramfs-kernel.bin
   bootm 0x46000000
   ```

2. Once booted into initramfs, extract kernel and rootfs from the sysupgrade image:
   ```bash
   cd /tmp
   wget <sysupgrade-image-url>
   tar -xf immortalwrt-*-clx_s20l-squashfs-sysupgrade.bin
   ```
   This will produce `kernel` and `root` files.

3. Flash the extracted images to the corresponding partitions:
   ```bash
   dd if=/tmp/kernel of=/dev/mmcblk0p4 bs=4M conv=fsync
   dd if=/tmp/root of=/dev/mmcblk0p5 bs=4M conv=fsync
   sync
   reboot
   ```

4. After reboot, the system will boot from eMMC.

### Notes
- The device uses a custom partition layout inherited from the vendor firmware, which differs from the standard OpenWrt eMMC layout.
- The kernel bootargs require `root=/dev/mmcblk0p5` to point to the rootfs partition (not p6, which is the user data partition).
- PCIe controller is disabled in the device tree since there is no physical PCIe slot on the board. However, it must be kept enabled in U-Boot to avoid affecting USB controller initialization due to shared power domains on MT7986A.
- WED (Wireless Ethernet Dispatcher) is enabled for hardware Wi-Fi offload.
- Hardware NAT offload (PPE) is built into the `mtk_eth_soc` driver (upstream implementation, no separate `mtk_hnat` module needed).
- The vendor U-Boot uses a web-based console interface accessible over the network, in addition to standard UART.

### Known Issues
- The `sysupgrade` command may not work correctly due to the custom partition layout. Use manual `dd` flashing for updates.
- The GPT backup header is misaligned (vendor issue), producing a warning at boot. Can be fixed with `gdisk /dev/mmcblk0` followed by `v` (verify) and `w` (write).

### Tested Features
- [x] Ethernet (all LAN + WAN ports)
- [x] Wi-Fi (2.4GHz + 5GHz)
- [x] USB 3.0
- [x] LEDs (status, wlan-2ghz, wlan-5ghz)
- [x] eMMC storage
- [x] Hardware crypto (EIP97)
- [x] WED Wi-Fi offload

### MAC Address Assignment
| Interface | Offset in `factory` partition |
|-----------|-------------------------------|
| LAN (band0 Wi-Fi) | 0x5 |
| WAN | 0x24 |
| Ethernet (gmac0) | 0x2a |
| 5GHz Wi-Fi (band1) | 0x30 |

### Recovery
If the device fails to boot, load the initramfs image via U-Boot TFTP and re-flash the kernel and rootfs partitions as described in the Installation section.