### PR TITLE
add support for RansNet mbox HSA-500

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -129,6 +129,10 @@ qxwlan,e2600ac-c2)
 	ucidef_set_led_wlan "wlan2g" "WLAN0" "green:wlan0" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN1" "green:wlan1" "phy1tpt"
 	;;
+mbox,hsa-500)
+	ucidef_set_led_netdev "lte" "LTE" "blue:lte" "wwan0"
+	ucidef_set_led_wlan "wifi" "WIFI" "blue:wifi" "phy0tpt"
+	;;
 sony,ncp-hg100-cellular)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ipq40xx_setup_interfaces()
 	linksys,mr6350|\
 	linksys,mr8300|\
 	linksys,mr9000|\
+	mbox,hsa-500|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
 	mikrotik,hap-ac3-lte6-kit|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -121,6 +121,7 @@ platform_do_upgrade() {
 	glinet,gl-a1300|\
 	glinet,gl-ap1300|\
 	luma,wrtq-329acn|\
+	mbox,hsa-500|\
 	mobipromo,cm520-79f|\
 	netgear,lbr20|\
 	netgear,rbr20|\

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mbox-hsa-500.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mbox-hsa-500.dts
@@ -1,0 +1,427 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+*
+* Copyright (c) 2026 Andi Rijal Habibi <isibondt@gmail.com>
+*
+*/
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Mbox HSA-500";
+	compatible = "mbox,hsa-500", "qcom,ipq4019";
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x20000000>;
+	};
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		serial1 = &blsp1_uart2;
+		ethernet0 = &gmac;
+		led-boot = &led_misc;
+		led-failsafe = &led_misc;
+		led-running = &led_misc;
+		led-upgrade = &led_misc;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 =
+				<TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+
+	reg_pcie_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie_power";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&tlmm 2 GPIO_ACTIVE_LOW>;
+		enable-active-low;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lte: lte {
+			label = "blue:lte";
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wifi: wifi {
+			label = "blue:wifi";
+			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_misc: misc {
+			label = "green:misc";
+			gpios = <&tlmm 39 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial0_pins: serial0-pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	serial1_pins: serial1-pinmux {
+		mux {
+			pins = "gpio8", "gpio9", "gpio10", "gpio11";
+			function = "blsp_uart1";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi-0-pinmux {
+		pinmux {
+			pins = "gpio13", "gpio14", "gpio15";
+			function = "blsp_spi0";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		pinmux-cs {
+			pins = "gpio12";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	nand_pins: nand-pins {
+		pullups {
+			pins = "gpio52", "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56", "gpio57",
+			       "gpio60", "gpio62", "gpio63", "gpio64",
+			       "gpio65", "gpio66", "gpio67", "gpio68",
+			       "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+
+	sd_pins: sd-pins {
+		data {
+			pins = "gpio23", "gpio24", "gpio25", "gpio26",
+			       "gpio28";
+			function = "sdio";
+			drive-strength = <10>;
+		};
+
+		clk {
+			pins = "gpio27";
+			function = "sdio";
+			drive-strength = <16>;
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&serial1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "0:CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "0:APPSBLENV";
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "0:APPSBL";
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+
+			art: partition@170000 {
+				label = "0:ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: mac-address@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: mac-address@6 {
+						reg = <0x6 0x6>;
+					};
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				/*
+				 * Do not rename this to "ubi": Qualcomm bootipq
+				 * forces ubi.mtd=rootfs on the vendor APPSBL.
+				 */
+				label = "rootfs";
+				reg = <0x00000000 0x04000000>;
+			};
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	num-channels = <4>;
+	qcom,num-ees = <2>;
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	phy-reset-gpios = <&tlmm 41 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&pcie0 {
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&vqmmc {
+	status = "okay";
+};
+
+&sdhci {
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+	cd-gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+	vqmmc-supply = <&vqmmc>;
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	label = "lan1";
+	status = "okay";
+};
+
+&swport2 {
+	label = "lan2";
+	status = "okay";
+};
+
+&swport3 {
+	label = "lan3";
+	status = "okay";
+};
+
+&swport4 {
+	label = "lan4";
+	status = "okay";
+};
+
+&swport5 {
+	label = "wan";
+	status = "okay";
+};
+
+&wifi0 {
+	nvmem-cells = <&precal_art_1000>;
+	nvmem-cell-names = "pre-calibration";
+	qcom,ath10k-calibration-variant = "Mbox-HSA-500";
+	status = "okay";
+};
+
+&wifi1 {
+	nvmem-cells = <&precal_art_5000>;
+	nvmem-cell-names = "pre-calibration";
+	qcom,ath10k-calibration-variant = "Mbox-HSA-500";
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -840,6 +840,32 @@ define Device/luma_wrtq-329acn
 endef
 TARGET_DEVICES += luma_wrtq-329acn
 
+define Device/mbox_hsa-500
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Mbox
+	DEVICE_MODEL := HSA-500
+	SOC := qcom-ipq4019
+	DEVICE_DTS := qcom-ipq4019-mbox-hsa-500
+	DEVICE_DTS_CONFIG := config@ap.dk07.1-c1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
+endef
+TARGET_DEVICES += mbox_hsa-500
+
+define Device/sony_ncp-hg100-cellular
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Sony
+	DEVICE_MODEL := NCP-HG100/Cellular
+	DEVICE_DTS_CONFIG := config@ap.dk04.1-c4
+	SOC := qcom-ipq4019
+	KERNEL_SIZE := 8192k
+	IMAGE_SIZE := 128m
+	DEVICE_PACKAGES := e2fsprogs kmod-fs-ext4 uqmi
+endef
+TARGET_DEVICES += sony_ncp-hg100-cellular
+
 define Device/meraki_common
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Cisco Meraki


### PR DESCRIPTION
add support for RansNet HSA-500 / Mbox HSA-500

This patch adds support for the RansNet HSA-500 (also known as Mbox HSA-500),
an IPQ4019-based cellular router with dual-band WiFi and LTE
extensibility.

Hardware Specifications:

SoC: Qualcomm Atheros IPQ4019 (Quad-Core ARM Cortex-A7)
RAM: 512 MiB DDR3
Storage: 16 MiB SPI NOR (Winbond W25Q128) + 128 MiB SPI NAND (Spansion S34ML01G1)
Ethernet: 5x 10/100/1000 Mbps (1x WAN, 4x LAN via QCA8075 DSA switch)
WiFi: Integrated IPQ4019 2.4 GHz (802.11n) + 5 GHz (802.11ac)
Expansion: 1x Mini-PCIe for LTE modem
LEDs: Blue LTE, Blue WiFi, Green Misc/Status
Buttons: WPS/Reset
Serial: BLSP1 UART1
Preparation before installation from oem firmware:

root@OpenWrt:~# fw_setenv bootcmd bootipq
root@OpenWrt:~# fw_setenv bootargs
root@OpenWrt:~# fw_setenv fsbootargs "ubi.mtd=rootfs root=/dev/ubiblock0_1 rootfstype=squashfs rootwait"
Installation via TFTP Recovery (OEM Bootloader):

Rename the built initramfs-uImage.itb file to
'openwrt-ipq40xx-generic-mbox_hsa-500-initramfs-uImage.itb'
and place it in your local TFTP root folder (Server IP: 192.168.10.175).
Connect your PC's Ethernet interface to the router's WAN port.
Access the U-Boot console via USB-to-TTL Serial connection.
Set the U-Boot environment variables if you dont set env in oem firmware:
(IPQ40xx) # setenv ipaddr 192.168.10.1
(IPQ40xx) # setenv serverip 192.168.10.175
(IPQ40xx) # tftpboot 0x88000000 openwrt-ipq40xx-generic-mbox_hsa-500-initramfs-uImage.itb
(IPQ40xx) # bootm 0x88000000
Once OpenWrt boots into the RAM disk, upload the factory UBI image:
$ scp openwrt-ipq40xx-generic-mbox_hsa-500-squashfs-factory.ubi root@192.168.10.1:/tmp/
Flash the firmware permanently to the NAND Flash:
ubidetach -p /dev/mtd0
ubiformat /dev/mtd0 -y -f /tmp/openwrt-ipq40xx-generic-mbox_hsa-500-squashfs-factory.ubi
reboot

<img width="1536" height="1024" alt="mbox hsa-500" src="https://github.com/user-attachments/assets/6a142585-b458-40ff-ac8a-3c3ac2a510f5" />

