### PR TITLE
[24.10] Backport changes related to projectsmirrors

### DIFF
--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -37,7 +37,6 @@
 		"https://ftpmirror.gnu.org",
 		"https://mirror.csclub.uwaterloo.ca/gnu",
 		"https://mirror.netcologne.de/gnu",
-		"https://ftp.kddilabs.jp/GNU/gnu",
 		"https://www.nic.funet.fi/pub/gnu/gnu",
 		"https://mirror.navercorp.com/gnu",
 		"https://mirrors.rit.edu/gnu",

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -51,7 +51,6 @@
 		"https://cdimage.debian.org/mirror/gnu.org/savannah"
 	],
 	"@KERNEL": [
-		"https://mirror.iscas.ac.cn/kernel.org",
 		"https://mirrors.ustc.edu.cn/kernel.org",
 		"https://mirror.nju.edu.cn/kernel.org",
 		"https://cdn.kernel.org/pub",

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -24,7 +24,7 @@
 		"https://mirror.navercorp.com/apache",
 		"https://ftp.jaist.ac.jp/pub/apache",
 		"https://apache.cs.utah.edu",
-		"http://apache.mirrors.ovh.net/ftp.apache.org/dist"
+		"https://apache.mirrors.ovh.net/ftp.apache.org/dist"
 	],
         "@GITHUB": [
                 "https://raw.githubusercontent.com"

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -58,7 +58,6 @@
 		"https://mirrors.mit.edu/kernel",
 		"http://ftp.nara.wide.ad.jp/pub/kernel.org",
 		"http://www.ring.gr.jp/archives/linux/kernel.org",
-		"https://ftp.riken.jp/Linux/kernel.org",
 		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub"
 	],
 	"@GNOME": [

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -56,15 +56,12 @@
 		"https://mirror.nju.edu.cn/kernel.org",
 		"https://cdn.kernel.org/pub",
 		"https://mirrors.mit.edu/kernel",
-		"http://ftp.nara.wide.ad.jp/pub/kernel.org",
-		"http://www.ring.gr.jp/archives/linux/kernel.org",
 		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub"
 	],
 	"@GNOME": [
 		"https://mirror.nju.edu.cn/gnome",
 		"https://download.gnome.org/sources",
-		"https://mirror.csclub.uwaterloo.ca/gnome/sources",
-		"http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources"
+		"https://mirror.csclub.uwaterloo.ca/gnome/sources"
 	],
 	"@OPENWRT": [
 		"https://sources.cdn.openwrt.org",

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -62,12 +62,9 @@
 		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub"
 	],
 	"@GNOME": [
-		"https://mirrors.ustc.edu.cn/gnome/sources",
 		"https://mirror.nju.edu.cn/gnome",
 		"https://download.gnome.org/sources",
 		"https://mirror.csclub.uwaterloo.ca/gnome/sources",
-		"https://ftp.acc.umu.se/pub/GNOME/sources",
-		"http://ftp.cse.buffalo.edu/pub/Gnome/sources",
 		"http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources"
 	],
 	"@OPENWRT": [

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -23,7 +23,7 @@
 		"https://mirror.cogentco.com/pub/apache",
 		"https://mirror.navercorp.com/apache",
 		"https://ftp.jaist.ac.jp/pub/apache",
-		"https://apache.cs.utah.edu/apache.org",
+		"https://apache.cs.utah.edu",
 		"http://apache.mirrors.ovh.net/ftp.apache.org/dist"
 	],
         "@GITHUB": [


### PR DESCRIPTION
Some mirror sites are invalid, which will cause some downloads to time out during compilation, making the compilation process take a long time.

https://github.com/openwrt/openwrt/pull/19407
https://github.com/openwrt/openwrt/pull/19509
https://github.com/openwrt/openwrt/pull/21268