### PR TITLE
sunxi: add support for Orange Pi 3 LTS

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -234,6 +234,15 @@ define U-Boot/orangepi_one_plus
   ATF:=h6
 endef
 
+define U-Boot/orangepi_3_lts
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=Orange Pi 3 LTS (H6)
+  DEPENDS:=+PACKAGE_u-boot-orangepi_3_lts:trusted-firmware-a-sunxi-h6
+  BUILD_DEVICES:=xunlong_orangepi-3-lts
+  UENV:=h6
+  ATF:=h6
+endef
+
 define U-Boot/orangepi_pc
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi PC (H3)
@@ -494,6 +503,7 @@ UBOOT_TARGETS := \
 	orangepi_r1 \
 	orangepi_one \
 	orangepi_one_plus \
+	orangepi_3_lts \
 	orangepi_pc \
 	orangepi_pc_plus \
 	orangepi_plus \

--- a/package/boot/uboot-sunxi/patches/001-sunxi-add-orangepi-3-lts.patch
+++ b/package/boot/uboot-sunxi/patches/001-sunxi-add-orangepi-3-lts.patch
@@ -1,0 +1,412 @@
+From 65a3bafb3f5a8c83b678b59cb4b7bb87d12e7cd0 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@gmail.com>
+Date: Tue, 7 Feb 2023 17:43:14 +0100
+Subject: [PATCH] sunxi: Add OrangePi 3 LTS board
+
+Orange Pi 3 LTS is an Allwinner H6 board with LPDDR3 memory. Add its
+device tree and defconfig so U-Boot can initialize the board and boot from
+SD or eMMC storage.
+
+Signed-off-by: Jernej Skrabec <jernej.skrabec@gmail.com>
+---
+ arch/arm/dts/Makefile                     |   1 +
+ arch/arm/dts/sun50i-h6-orangepi-3-lts.dts | 349 ++++++++++++++++++++++
+ configs/orangepi_3_lts_defconfig          |  19 ++
+ 3 files changed, 369 insertions(+)
+ create mode 100644 arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
+ create mode 100644 configs/orangepi_3_lts_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 965895bc2a3c..501400635fa9 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -702,6 +702,7 @@ dtb-$(CONFIG_MACH_SUN50I_H5) += \
+ dtb-$(CONFIG_MACH_SUN50I_H6) += \
+ 	sun50i-h6-beelink-gs1.dtb \
+ 	sun50i-h6-orangepi-3.dtb \
++	sun50i-h6-orangepi-3-lts.dtb \
+ 	sun50i-h6-orangepi-lite2.dtb \
+ 	sun50i-h6-orangepi-one-plus.dtb \
+ 	sun50i-h6-pine-h64.dtb \
+diff --git a/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
+new file mode 100644
+index 000000000000..6a5df1103a90
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h6-orangepi-3-lts.dts
+@@ -0,0 +1,349 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (C) 2023 Jernej Skrabec <jernej.skrabec@gmail.com>
++// Based on sun50i-h6-orangepi-3.dts, which is:
++// Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
++
++/dts-v1/;
++
++#include "sun50i-h6.dtsi"
++#include "sun50i-h6-cpu-opp.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "OrangePi 3 LTS";
++	compatible = "xunlong,orangepi-3-lts", "allwinner,sun50i-h6";
++
++	aliases {
++		ethernet0 = &emac;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		ddc-en-gpios = <&pio 7 2 GPIO_ACTIVE_HIGH>; /* PH2 */
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	ext_osc32k: ext_osc32k_clk {
++		#clock-cells = <0>;
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "ext_osc32k";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "orangepi:red:power";
++			gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
++			default-state = "on";
++		};
++
++		led-1 {
++			label = "orangepi:green:status";
++			gpios = <&r_pio 0 7 GPIO_ACTIVE_HIGH>; /* PL7 */
++		};
++	};
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <150000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>; /* PD6 */
++	};
++
++	reg_vcc33_wifi: vcc33-wifi {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc33-wifi";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpio = <&pio 7 7 GPIO_ACTIVE_HIGH>; /* PH7 */
++	};
++
++	reg_vcc_wifi_io: vcc-wifi-io {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-wifi-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		vin-supply = <&reg_vcc33_wifi>;
++	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
++		reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PL3 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply directly from the DC jack */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdca>;
++};
++
++&de {
++	status = "okay";
++};
++
++&dwc3 {
++	status = "okay";
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ext_rgmii_pins>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ext_rgmii_phy>;
++	phy-supply = <&reg_gmac_3v3>;
++	allwinner,rx-delay-ps = <200>;
++	allwinner,tx-delay-ps = <300>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&reg_dcdcc>;
++	status = "okay";
++};
++
++&hdmi {
++	hvcc-supply = <&reg_bldo2>;
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++		motorcomm,clk-out-frequency-hz = <125000000>;
++
++		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
++		reset-assert-us = <15000>;
++		reset-deassert-us = <40000>;
++	};
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_cldo1>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	bus-width = <4>;
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc33_wifi>;
++	vqmmc-supply = <&reg_vcc_wifi_io>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++};
++
++&mmc2 {
++	vmmc-supply = <&reg_cldo1>;
++	vqmmc-supply = <&reg_bldo2>;
++	cap-mmc-hw-reset;
++	non-removable;
++	bus-width = <8>;
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&pio {
++	vcc-pc-supply = <&reg_bldo2>;
++	vcc-pd-supply = <&reg_cldo1>;
++	vcc-pg-supply = <&reg_bldo3>;
++};
++
++&r_ir {
++	status = "okay";
++};
++
++&r_i2c {
++	status = "okay";
++
++	axp805: pmic@36 {
++		compatible = "x-powers,axp805", "x-powers,axp806";
++		reg = <0x36>;
++		interrupt-parent = <&r_intc>;
++		interrupts = <GIC_SPI 96 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-controller;
++		#interrupt-cells = <1>;
++		x-powers,self-working-mode;
++		vina-supply = <&reg_vcc5v>;
++		vinb-supply = <&reg_vcc5v>;
++		vinc-supply = <&reg_vcc5v>;
++		vind-supply = <&reg_vcc5v>;
++		vine-supply = <&reg_vcc5v>;
++		aldoin-supply = <&reg_vcc5v>;
++		bldoin-supply = <&reg_vcc5v>;
++		cldoin-supply = <&reg_vcc5v>;
++
++		regulators {
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc-pl-led-ir";
++			};
++
++			reg_aldo2: aldo2 {
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc33-audio-tv-ephy-mac";
++			};
++
++			/* ALDO3 is shorted to CLDO1 */
++			reg_aldo3: aldo3 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc33-io-pd-emmc-sd-usb-uart-1";
++			};
++
++			reg_bldo1: bldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc18-dram-bias-pll";
++			};
++
++			reg_bldo2: bldo2 {
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc-efuse-pcie-hdmi-pc";
++			};
++
++			reg_bldo3: bldo3 {
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc-pm-pg-dcxoio-wifi";
++			};
++
++			bldo4 {
++				/* unused */
++			};
++
++			reg_cldo1: cldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc33-io-pd-emmc-sd-usb-uart-2";
++			};
++
++			cldo2 {
++				/* unused */
++			};
++
++			cldo3 {
++				/* unused */
++			};
++
++			reg_dcdca: dcdca {
++				regulator-always-on;
++				regulator-min-microvolt = <800000>;
++				regulator-max-microvolt = <1160000>;
++				regulator-ramp-delay = <2500>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdcc: dcdcc {
++				regulator-enable-ramp-delay = <32000>;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1080000>;
++				regulator-ramp-delay = <2500>;
++				regulator-name = "vdd-gpu";
++			};
++
++			reg_dcdcd: dcdcd {
++				regulator-always-on;
++				regulator-min-microvolt = <960000>;
++				regulator-max-microvolt = <960000>;
++				regulator-name = "vdd-sys";
++			};
++
++			reg_dcdce: dcdce {
++				regulator-always-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "vcc-dram";
++			};
++
++			sw {
++				/* unused */
++			};
++		};
++	};
++};
++
++&rtc {
++	clocks = <&ext_osc32k>;
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&usb2otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb2phy {
++	usb0_id_det-gpios = <&pio 2 15 GPIO_ACTIVE_HIGH>; /* PC15 */
++	usb0_vbus-supply = <&reg_vcc5v>;
++	usb3_vbus-supply = <&reg_vcc5v>;
++	status = "okay";
++};
++
++&usb3phy {
++	status = "okay";
++};
+diff --git a/configs/orangepi_3_lts_defconfig b/configs/orangepi_3_lts_defconfig
+new file mode 100644
+index 000000000000..41a9af4ef67a
+--- /dev/null
++++ b/configs/orangepi_3_lts_defconfig
+@@ -0,0 +1,19 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h6-orangepi-3-lts"
++CONFIG_SPL=y
++CONFIG_MACH_SUN50I_H6=y
++CONFIG_SUNXI_DRAM_H6_LPDDR3=y
++CONFIG_MMC0_CD_PIN="PF6"
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_STACK=0x118000
++CONFIG_SYS_PBSIZE=1024
++CONFIG_SYS_BOOTM_LEN=0x2000000
++CONFIG_PHY_SUN50I_USB3=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
+-- 
+2.39.1

--- a/package/firmware/uwe5622-firmware/Makefile
+++ b/package/firmware/uwe5622-firmware/Makefile
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uwe5622-firmware
+PKG_VERSION:=2023.09.02
+PKG_RELEASE:=1
+
+FW_SOURCE_VERSION:=612bc7cc0e3539ea89c659049b7d8432e2de8ed7
+
+PKG_LICENSE:=Redistributable
+PKG_MAINTAINER:=jukeboge <jukeboge@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Download/uwe5622-wcnmodem
+  URL:=https://raw.githubusercontent.com/armbian/firmware/$(FW_SOURCE_VERSION)/uwe5622
+  URL_FILE:=wcnmodem.bin
+  FILE:=uwe5622-wcnmodem.bin
+  HASH:=119b87ce30875734a67462f7293fb8fe85acf3270fe8b78c978ae24be7715a80
+endef
+$(eval $(call Download,uwe5622-wcnmodem))
+
+define Download/uwe5622-wifi-config
+  URL:=https://raw.githubusercontent.com/armbian/firmware/$(FW_SOURCE_VERSION)/uwe5622
+  URL_FILE:=wifi_2355b001_1ant.ini
+  FILE:=uwe5622-wifi_2355b001_1ant.ini
+  HASH:=1f3c40ec245a8d0b99ad1c23706597d6dd5008ab80cefb7bcc1956efc4e938f7
+endef
+$(eval $(call Download,uwe5622-wifi-config))
+
+define Package/uwe5622-firmware
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  TITLE:=UNISOC UWE5622 firmware
+  URL:=https://github.com/armbian/firmware/tree/master/uwe5622
+endef
+
+define Build/Compile
+endef
+
+define Package/uwe5622-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/uwe5622
+	$(INSTALL_DATA) $(DL_DIR)/uwe5622-wcnmodem.bin \
+		$(1)/lib/firmware/uwe5622/wcnmodem.bin
+	$(INSTALL_DATA) $(DL_DIR)/uwe5622-wifi_2355b001_1ant.ini \
+		$(1)/lib/firmware/uwe5622/wifi_2355b001_1ant.ini
+endef
+
+$(eval $(call BuildPackage,uwe5622-firmware))

--- a/package/kernel/uwe5622/Makefile
+++ b/package/kernel/uwe5622/Makefile
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uwe5622
+PKG_VERSION:=2026.08.15
+PKG_RELEASE:=2
+
+PKG_SOURCE_VERSION:=d6bec7538a0b4b67e35715ad71eaa056555524cb
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/armbian/uwe5622/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_HASH:=d85333868862d820f2dae3379ee7b9962ebfd8aeb1ee9cb84c66c725f292ea11
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=README.md
+PKG_MAINTAINER:=jukeboge <jukeboge@gmail.com>
+PKG_BUILD_PARALLEL:=1
+PKG_EXTMOD_SUBDIRS:=unisocwcn unisocwifi
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/uwe5622
+  SUBMENU:=Wireless Drivers
+  TITLE:=UNISOC UWE5622 (AW859A) SDIO wireless driver
+  URL:=https://github.com/armbian/uwe5622
+  DEPENDS:=@TARGET_sunxi_cortexa53 +kmod-cfg80211 +uwe5622-firmware
+  FILES:= \
+	$(PKG_BUILD_DIR)/unisocwcn/uwe5622_bsp_sdio.ko \
+	$(PKG_BUILD_DIR)/unisocwifi/sprdwl_ng.ko
+  AUTOLOAD:=$(call AutoLoad,30,uwe5622_bsp_sdio)
+endef
+
+define KernelPackage/uwe5622/description
+  Community-maintained SDIO Wi-Fi driver for the UNISOC UWE5622 chipset
+  used by the AW859A module on the Orange Pi 3 LTS.
+endef
+
+define KernelPackage/uwe5622/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/sprdwl-delay $(1)/etc/init.d/sprdwl-delay
+endef
+
+define Build/Configure
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR)/unisocwcn/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/autoconf.h \
+	-include backport/backport.h \
+	-DOPENWRT_CFG80211_BACKPORT
+
+define Build/Compile
+	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		M=$(PKG_BUILD_DIR)/unisocwcn \
+		CONFIG_AW_WIFI_DEVICE_UWE5622=y \
+		CONFIG_AW_BIND_VERIFY=y \
+		UNISOC_FW_PATH_CONFIG=\"/lib/firmware/uwe5622/\" \
+		modules
+	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		M=$(PKG_BUILD_DIR)/unisocwifi \
+		CONFIG_WLAN_UWE5622=m \
+		UNISOC_BSP_INCLUDE=$(PKG_BUILD_DIR)/unisocwcn/include \
+		UNISOC_WIFI_CUS_CONFIG=/lib/firmware/uwe5622 \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		KBUILD_EXTRA_SYMBOLS="$(KERNEL_BUILD_DIR)/symvers/mac80211.symvers $(PKG_BUILD_DIR)/unisocwcn/Module.symvers" \
+		modules
+endef
+
+$(eval $(call KernelPackage,uwe5622))

--- a/package/kernel/uwe5622/files/sprdwl-delay
+++ b/package/kernel/uwe5622/files/sprdwl-delay
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+start_service() {
+	# Loading sprdwl_ng while netifd is registering the Ethernet bridge can
+	# stall early network initialisation. Keep the UWE5622 SDIO transport in
+	# modules.d, then register the wireless interface after boot. Firmware
+	# startup is asynchronous, so wait for the wiphy before starting Wi-Fi.
+	procd_open_instance
+	procd_set_param command /bin/sh -c \
+		'sleep 10; /sbin/modprobe sprdwl_ng || exit 1; i=0; while [ ! -e /sys/class/ieee80211/phy0 ] && [ "$i" -lt 30 ]; do sleep 1; i=$((i + 1)); done; [ -e /sys/class/ieee80211/phy0 ] || exit 1; /sbin/wifi up radio0'
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/package/kernel/uwe5622/patches/010-openwrt-cfg80211-backport-api.patch
+++ b/package/kernel/uwe5622/patches/010-openwrt-cfg80211-backport-api.patch
@@ -1,0 +1,20 @@
+From: jukeboge <jukeboge@gmail.com>
+Subject: [PATCH] uwe5622: support OpenWrt's backported cfg80211 API
+
+OpenWrt backports the current cfg80211 API to older target kernels, so the
+kernel version alone cannot select the change_beacon callback prototype.
+
+Signed-off-by: jukeboge <jukeboge@gmail.com>
+---
+--- a/unisocwifi/cfg80211.c
++++ b/unisocwifi/cfg80211.c
+@@ -1095,7 +1095,8 @@ static int sprdwl_cfg80211_start_ap(struc
+ 	return ret;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0) || \
++	defined(OPENWRT_CFG80211_BACKPORT)
+ static int sprdwl_cfg80211_change_beacon(struct wiphy *wiphy,
+ 					 struct net_device *ndev,
+ 					 struct cfg80211_ap_update *info)

--- a/package/kernel/uwe5622/patches/020-enable-external-kbuild-config-symbols.patch
+++ b/package/kernel/uwe5622/patches/020-enable-external-kbuild-config-symbols.patch
@@ -1,0 +1,21 @@
+From: jukeboge <jukeboge@gmail.com>
+Subject: [PATCH] uwe5622: honor bind verification Kbuild option
+
+Propagate CONFIG_AW_BIND_VERIFY from an external-module build into the
+preprocessor flags used by the transport driver.
+
+Signed-off-by: jukeboge <jukeboge@gmail.com>
+---
+--- a/unisocwcn/Makefile
++++ b/unisocwcn/Makefile
+@@ -85,6 +85,10 @@ BSP_CHIP_ID := uwe5622
+ WCN_HW_TYPE := sdio
+ endif
+ 
++ifeq ($(CONFIG_AW_BIND_VERIFY),y)
++ccflags-y += -DCONFIG_AW_BIND_VERIFY=1
++endif
++
+ MODULE_NAME := $(BSP_CHIP_ID)_bsp_$(WCN_HW_TYPE)
+ 
+ ifneq ($(UNISOC_FW_PATH_CONFIG),)

--- a/package/kernel/uwe5622/patches/030-fix-cfg80211-netdev-locking.patch
+++ b/package/kernel/uwe5622/patches/030-fix-cfg80211-netdev-locking.patch
@@ -1,0 +1,162 @@
+From: jukeboge <jukeboge@gmail.com>
+Subject: [PATCH] uwe5622: use cfg80211 netdev helpers in interface callbacks
+
+cfg80211 add_virtual_intf and del_virtual_intf callbacks run while the
+wireless core already holds the network device lock. Calling the generic
+register_netdevice() and unregister_netdevice() helpers from that context
+causes a recursive lock and prevents AP interfaces from being created.
+
+Use the cfg80211-aware helpers in callback context while retaining the
+generic helpers for the driver's core initialization and teardown paths.
+
+Signed-off-by: jukeboge <jukeboge@gmail.com>
+---
+--- a/unisocwifi/sprdwl.h
++++ b/unisocwifi/sprdwl.h
+@@ -402,8 +402,10 @@ void sprdwl_net_flowcontrl(struct sprdwl
+ 
+ struct wireless_dev *sprdwl_add_iface(struct sprdwl_priv *priv,
+ 				      const char *name,
+-				      enum nl80211_iftype type, u8 *addr);
+-int sprdwl_del_iface(struct sprdwl_priv *priv, struct sprdwl_vif *vif);
++				      enum nl80211_iftype type, u8 *addr,
++				      bool cfg80211_locked);
++int sprdwl_del_iface(struct sprdwl_priv *priv, struct sprdwl_vif *vif,
++		     bool cfg80211_locked);
+ struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
+ 				       struct sprdwl_if_ops *ops);
+ void sprdwl_core_free(struct sprdwl_priv *priv);
+--- a/unisocwifi/main.c
++++ b/unisocwifi/main.c
+@@ -1380,6 +1380,7 @@ static struct sprdwl_vif *sprdwl_registe
+ 						 const char *name,
+ 						 enum nl80211_iftype type,
+-						 u8 *addr)
++						 u8 *addr,
++						 bool cfg80211_locked)
+ {
+ 	struct net_device *ndev;
+ 	struct wireless_dev *wdev;
+@@ -1451,7 +1452,10 @@ static struct sprdwl_vif *sprdwl_registe
+ #endif
+ 
+ 	/* register new Ethernet interface */
+-	ret = register_netdevice(ndev);
++	if (cfg80211_locked)
++		ret = cfg80211_register_netdevice(ndev);
++	else
++		ret = register_netdevice(ndev);
+ 	if (ret) {
+ 		wl_ndev_log(L_ERR, ndev, "failed to regitster netdev(%d)!\n", ret);
+ 		goto err;
+@@ -1466,19 +1470,24 @@ err:
+ 	return ERR_PTR(ret);
+ }
+ 
+-static void sprdwl_unregister_netdev(struct sprdwl_vif *vif)
++static void sprdwl_unregister_netdev(struct sprdwl_vif *vif,
++				     bool cfg80211_locked)
+ {
+ 	wl_info("iface '%s' deleted\n", vif->ndev->name);
+ 
+ 	if (vif->priv->fw_capa & SPRDWL_CAPA_MC_FILTER)
+ 		kfree(vif->mc_filter);
+ 	sprdwl_deinit_vif(vif);
+-	unregister_netdevice(vif->ndev);
++	if (cfg80211_locked)
++		cfg80211_unregister_netdevice(vif->ndev);
++	else
++		unregister_netdevice(vif->ndev);
+ }
+ 
+ struct wireless_dev *sprdwl_add_iface(struct sprdwl_priv *priv,
+ 				      const char *name,
+-				      enum nl80211_iftype type, u8 *addr)
++				      enum nl80211_iftype type, u8 *addr,
++				      bool cfg80211_locked)
+ {
+ 	struct sprdwl_vif *vif;
+ 
+@@ -1486,9 +1495,11 @@ struct wireless_dev *sprdwl_add_iface(st
+ 	if (type == NL80211_IFTYPE_P2P_DEVICE)
+ 		vif = sprdwl_register_wdev(priv, name, type, addr);
+ 	else
+-		vif = sprdwl_register_netdev(priv, name, type, addr);
++		vif = sprdwl_register_netdev(priv, name, type, addr,
++					     cfg80211_locked);
+ #else
+-	vif = sprdwl_register_netdev(priv, name, type, addr);
++	vif = sprdwl_register_netdev(priv, name, type, addr,
++				     cfg80211_locked);
+ #endif
+ 
+ 	if (IS_ERR(vif)) {
+@@ -1510,15 +1521,16 @@ struct wireless_dev *sprdwl_add_iface(st
+ 	return &vif->wdev;
+ }
+ 
+-int sprdwl_del_iface(struct sprdwl_priv *priv, struct sprdwl_vif *vif)
++int sprdwl_del_iface(struct sprdwl_priv *priv, struct sprdwl_vif *vif,
++		     bool cfg80211_locked)
+ {
+ #ifdef DFS_MASTER
+ 	sprdwl_deinit_dfs_master(vif);
+ #endif
+ 	if (!vif->ndev)
+ 		sprdwl_unregister_wdev(vif);
+ 	else
+-		sprdwl_unregister_netdev(vif);
++		sprdwl_unregister_netdev(vif, cfg80211_locked);
+ 
+ 	return 0;
+ }
+@@ -1533,7 +1545,7 @@ next_intf:
+ 		list_del(&vif->vif_node);
+ 		spin_unlock_bh(&priv->list_lock);
+ 		rtnl_lock();
+-		sprdwl_del_iface(priv, vif);
++		sprdwl_del_iface(priv, vif, false);
+ 		rtnl_unlock();
+ 		goto next_intf;
+ 	}
+@@ -1583,7 +1595,8 @@ int sprdwl_core_init(struct device *dev,
+ 	if (is_valid_ether_addr(priv->mac_addr))
+ 		efuse_mac_addr = priv->mac_addr;
+ 	rtnl_lock();
+-	wdev = sprdwl_add_iface(priv, "wlan%d", NL80211_IFTYPE_STATION, NULL);
++	wdev = sprdwl_add_iface(priv, "wlan%d", NL80211_IFTYPE_STATION, NULL,
++				false);
+ 	rtnl_unlock();
+ 	if (IS_ERR(wdev)) {
+ 		wiphy_unregister(wiphy);
+@@ -1593,7 +1606,8 @@ int sprdwl_core_init(struct device *dev,
+ 
+ #ifdef CONFIG_P2P_INTF
+ 	rtnl_lock();
+-	wdev = sprdwl_add_iface(priv, "p2p%d", NL80211_IFTYPE_P2P_DEVICE, NULL);
++	wdev = sprdwl_add_iface(priv, "p2p%d", NL80211_IFTYPE_P2P_DEVICE, NULL,
++				false);
+ 	rtnl_unlock();
+ 	if (IS_ERR(wdev)) {
+ 		wiphy_unregister(wiphy);
+--- a/unisocwifi/cfg80211.c
++++ b/unisocwifi/cfg80211.c
+@@ -559,7 +559,8 @@ static struct wireless_dev *sprdwl_cfg80
+ 		}
+ 	}
+ 
+-	return sprdwl_add_iface(priv, name, iftype, params->macaddr);
++	return sprdwl_add_iface(priv, name, iftype, params->macaddr,
++				true);
+ }
+ #endif
+ 
+@@ -581,7 +582,7 @@ static int sprdwl_cfg80211_del_iface(str
+ 	spin_unlock_bh(&priv->list_lock);
+ 
+ 	if (vif != NULL) {
+-		sprdwl_del_iface(priv, vif);
++		sprdwl_del_iface(priv, vif, true);
+ 
+ 		spin_lock_bh(&priv->list_lock);
+ 		list_del(&vif->vif_node);

--- a/target/linux/sunxi/files-6.18/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
+++ b/target/linux/sunxi/files-6.18/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+// Copyright (C) 2023 Jernej Skrabec <jernej.skrabec@gmail.com>
+// Based on sun50i-h6-orangepi-3.dts, which is:
+// Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
+
+/dts-v1/;
+
+#include "sun50i-h6.dtsi"
+#include "sun50i-h6-cpu-opp.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "OrangePi 3 LTS";
+	compatible = "xunlong,orangepi-3-lts", "allwinner,sun50i-h6";
+
+	aliases {
+		ethernet0 = &emac;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	connector {
+		compatible = "hdmi-connector";
+		ddc-en-gpios = <&pio 7 2 GPIO_ACTIVE_HIGH>; /* PH2 */
+		type = "a";
+
+		port {
+			hdmi_con_in: endpoint {
+				remote-endpoint = <&hdmi_out_con>;
+			};
+		};
+	};
+
+	ext_osc32k: ext_osc32k_clk {
+		#clock-cells = <0>;
+		compatible = "fixed-clock";
+		clock-frequency = <32768>;
+		clock-output-names = "ext_osc32k";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "orangepi:red:power";
+			gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
+			default-state = "on";
+		};
+
+		led-1 {
+			label = "orangepi:green:status";
+			gpios = <&r_pio 0 7 GPIO_ACTIVE_HIGH>; /* PL7 */
+		};
+	};
+
+	reg_gmac_3v3: gmac-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "gmac-3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		startup-delay-us = <150000>;
+		enable-active-high;
+		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>; /* PD6 */
+	};
+
+	reg_vcc33_wifi: vcc33-wifi {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc33-wifi";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpio = <&pio 7 7 GPIO_ACTIVE_HIGH>; /* PH7 */
+	};
+
+	reg_vcc_wifi_io: vcc-wifi-io {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-wifi-io";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		vin-supply = <&reg_vcc33_wifi>;
+	};
+
+	wifi_pwrseq: wifi-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		clocks = <&rtc 1>;
+		clock-names = "ext_clock";
+		reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PL3 */
+		post-power-on-delay-ms = <200>;
+	};
+
+	reg_vcc5v: vcc5v {
+		/* board wide 5V supply directly from the DC jack */
+		compatible = "regulator-fixed";
+		regulator-name = "vcc-5v";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+};
+
+&cpu0 {
+	cpu-supply = <&reg_dcdca>;
+};
+
+&de {
+	status = "okay";
+};
+
+&dwc3 {
+	status = "okay";
+};
+
+&ehci0 {
+	status = "okay";
+};
+
+&ehci3 {
+	status = "okay";
+};
+
+&emac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ext_rgmii_pins>;
+	phy-mode = "rgmii-id";
+	phy-handle = <&ext_rgmii_phy>;
+	phy-supply = <&reg_gmac_3v3>;
+	allwinner,rx-delay-ps = <200>;
+	allwinner,tx-delay-ps = <300>;
+	status = "okay";
+};
+
+&gpu {
+	mali-supply = <&reg_dcdcc>;
+	status = "okay";
+};
+
+&hdmi {
+	hvcc-supply = <&reg_bldo2>;
+	status = "okay";
+};
+
+&hdmi_out {
+	hdmi_out_con: endpoint {
+		remote-endpoint = <&hdmi_con_in>;
+	};
+};
+
+&mdio {
+	ext_rgmii_phy: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+		motorcomm,clk-out-frequency-hz = <125000000>;
+
+		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
+		reset-assert-us = <15000>;
+		reset-deassert-us = <40000>;
+	};
+};
+
+&mmc0 {
+	vmmc-supply = <&reg_cldo1>;
+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
+	bus-width = <4>;
+	status = "okay";
+};
+
+&mmc1 {
+	vmmc-supply = <&reg_vcc33_wifi>;
+	vqmmc-supply = <&reg_vcc_wifi_io>;
+	mmc-pwrseq = <&wifi_pwrseq>;
+	bus-width = <4>;
+	non-removable;
+	status = "okay";
+};
+
+&mmc2 {
+	vmmc-supply = <&reg_cldo1>;
+	vqmmc-supply = <&reg_bldo2>;
+	cap-mmc-hw-reset;
+	non-removable;
+	bus-width = <8>;
+	status = "okay";
+};
+
+&ohci0 {
+	status = "okay";
+};
+
+&ohci3 {
+	status = "okay";
+};
+
+&pio {
+	vcc-pc-supply = <&reg_bldo2>;
+	vcc-pd-supply = <&reg_cldo1>;
+	vcc-pg-supply = <&reg_bldo3>;
+};
+
+&r_ir {
+	status = "okay";
+};
+
+&r_i2c {
+	status = "okay";
+
+	axp805: pmic@36 {
+		compatible = "x-powers,axp805", "x-powers,axp806";
+		reg = <0x36>;
+		interrupt-parent = <&r_intc>;
+		interrupts = <GIC_SPI 96 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		x-powers,self-working-mode;
+		vina-supply = <&reg_vcc5v>;
+		vinb-supply = <&reg_vcc5v>;
+		vinc-supply = <&reg_vcc5v>;
+		vind-supply = <&reg_vcc5v>;
+		vine-supply = <&reg_vcc5v>;
+		aldoin-supply = <&reg_vcc5v>;
+		bldoin-supply = <&reg_vcc5v>;
+		cldoin-supply = <&reg_vcc5v>;
+
+		regulators {
+			reg_aldo1: aldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc-pl-led-ir";
+			};
+
+			reg_aldo2: aldo2 {
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc33-audio-tv-ephy-mac";
+			};
+
+			/* ALDO3 is shorted to CLDO1 */
+			reg_aldo3: aldo3 {
+				regulator-always-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc33-io-pd-emmc-sd-usb-uart-1";
+			};
+
+			reg_bldo1: bldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc18-dram-bias-pll";
+			};
+
+			reg_bldo2: bldo2 {
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc-efuse-pcie-hdmi-pc";
+			};
+
+			reg_bldo3: bldo3 {
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc-pm-pg-dcxoio-wifi";
+			};
+
+			bldo4 {
+				/* unused */
+			};
+
+			reg_cldo1: cldo1 {
+				regulator-always-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc33-io-pd-emmc-sd-usb-uart-2";
+			};
+
+			cldo2 {
+				/* unused */
+			};
+
+			cldo3 {
+				/* unused */
+			};
+
+			reg_dcdca: dcdca {
+				regulator-always-on;
+				regulator-min-microvolt = <800000>;
+				regulator-max-microvolt = <1160000>;
+				regulator-ramp-delay = <2500>;
+				regulator-name = "vdd-cpu";
+			};
+
+			reg_dcdcc: dcdcc {
+				regulator-enable-ramp-delay = <32000>;
+				regulator-min-microvolt = <810000>;
+				regulator-max-microvolt = <1080000>;
+				regulator-ramp-delay = <2500>;
+				regulator-name = "vdd-gpu";
+			};
+
+			reg_dcdcd: dcdcd {
+				regulator-always-on;
+				regulator-min-microvolt = <960000>;
+				regulator-max-microvolt = <960000>;
+				regulator-name = "vdd-sys";
+			};
+
+			reg_dcdce: dcdce {
+				regulator-always-on;
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-name = "vcc-dram";
+			};
+
+			sw {
+				/* unused */
+			};
+		};
+	};
+};
+
+&rtc {
+	clocks = <&ext_osc32k>;
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_ph_pins>;
+	status = "okay";
+};
+
+&usb2otg {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb2phy {
+	usb0_id_det-gpios = <&pio 2 15 GPIO_ACTIVE_HIGH>; /* PC15 */
+	usb0_vbus-supply = <&reg_vcc5v>;
+	usb3_vbus-supply = <&reg_vcc5v>;
+	status = "okay";
+};
+
+&usb3phy {
+	status = "okay";
+};

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -125,6 +125,15 @@ define Device/xunlong_orangepi-one-plus
 endef
 TARGET_DEVICES += xunlong_orangepi-one-plus
 
+define Device/xunlong_orangepi-3-lts
+  $(Device/sun50i-h6)
+  DEVICE_VENDOR := Xunlong
+  DEVICE_MODEL := Orange Pi 3 LTS
+  DEVICE_PACKAGES := kmod-uwe5622
+  SUPPORTED_DEVICES += xunlong,orangepi-3-lts
+endef
+TARGET_DEVICES += xunlong_orangepi-3-lts
+
 define Device/xunlong_orangepi-pc2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC 2

--- a/target/linux/sunxi/patches-6.18/411-arm64-dts-allwinner-add-orangepi-3-lts-target.patch
+++ b/target/linux/sunxi/patches-6.18/411-arm64-dts-allwinner-add-orangepi-3-lts-target.patch
@@ -1,0 +1,21 @@
+From: jukeboge <jukeboge@gmail.com>
+Date: Sun, 23 Aug 2026 00:00:00 +0800
+Subject: [PATCH] arm64: dts: allwinner: build Orange Pi 3 LTS DTB
+
+Add the Orange Pi 3 LTS device tree to the Allwinner arm64 DTB list.
+
+Signed-off-by: jukeboge <jukeboge@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -33,6 +33,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-beelink-gs1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3-lts.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-lite2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb


### PR DESCRIPTION
# sunxi: add support for Orange Pi 3 LTS

## Summary

- add an ImmortalWrt image profile and a dedicated U-Boot target for the Xunlong Orange Pi 3 LTS
- add the Linux and U-Boot device trees for the Allwinner H6 board
- package the community-maintained UNISOC UWE5622 SDIO transport and Wi-Fi driver used by the onboard AW859A module
- package the required, commit-pinned UWE5622 firmware and board configuration
- delay Wi-Fi registration until early network initialization has settled
- fix cfg80211 netdevice locking so AP interfaces can be created without a recursive lock

## Hardware

- Xunlong Orange Pi 3 LTS
- Allwinner H6 / ARM64
- 2 GiB LPDDR3
- 8 GiB eMMC
- Motorcomm YT8531 Gigabit Ethernet PHY
- AW859A module with UNISOC UWE5622 (chip ID `0x2355b001`)

## Build test

Built successfully from ImmortalWrt `master` at `604e315e` with:

- Linux 6.18.44
- U-Boot 2026.04
- GCC 14.4.0

The build produced and validated:

- ext4 and squashfs SD-card images
- an AArch64 FIT initramfs containing `sun50i-h6-orangepi-3-lts.dtb`
- `u-boot-sunxi-with-spl.bin` for `orangepi_3_lts`
- `uwe5622_bsp_sdio.ko` and `sprdwl_ng.ko`
- `kmod-uwe5622` and `uwe5622-firmware` APK packages

All generated target checksums pass and both compressed SD-card images pass `gzip -t`.

## Hardware test

The equivalent changes were tested on an Orange Pi 3 LTS running the ImmortalWrt 24.10.6 kernel baseline:

- boot from SD card and eMMC
- UART console at 115200 8N1
- eMMC detection and root filesystem
- YT8531 Ethernet link at 1 Gbit/s full duplex
- onboard UWE5622 Wi-Fi detection after a cold boot
- 2.4 GHz AP creation and automatic startup
- client association and DHCP address assignment

The master-based image in this PR was compile-tested and structurally validated, but was not flashed to hardware.

Signed-off-by: jukeboge <jukeboge@gmail.com>
