### PR TITLE
config: enable KERNEL_DYNAMIC_FTRACE by default for eBPF targets

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -354,6 +354,7 @@ config KERNEL_KALLSYMS
 config KERNEL_FTRACE
 	bool "Compile the kernel with tracing support"
 	depends on !TARGET_uml
+	default y if KERNEL_DEBUG_INFO_BTF
 
 config KERNEL_FTRACE_SYSCALLS
 	bool "Trace system calls"
@@ -366,6 +367,7 @@ config KERNEL_ENABLE_DEFAULT_TRACERS
 config KERNEL_FUNCTION_TRACER
 	bool "Function tracer"
 	depends on KERNEL_FTRACE
+	default y if KERNEL_DEBUG_INFO_BTF
 
 config KERNEL_FUNCTION_GRAPH_TRACER
 	bool "Function graph tracer"
@@ -374,6 +376,7 @@ config KERNEL_FUNCTION_GRAPH_TRACER
 config KERNEL_DYNAMIC_FTRACE
 	bool "Enable/disable function tracing dynamically"
 	depends on KERNEL_FUNCTION_TRACER
+	default y if KERNEL_DEBUG_INFO_BTF
 
 config KERNEL_FUNCTION_PROFILER
 	bool "Function profiler"


### PR DESCRIPTION
Closes #2452

On 25.12.1 (kernel 6.12.94), dae's TCP relay eBPF offload can't attach via fentry and falls back to a kprobe on `skb_send_sock_locked` with `EBUSY`. The target kernel is built without `CONFIG_DYNAMIC_FTRACE`, which fentry requires.

Enable `KERNEL_DYNAMIC_FTRACE` (and its `KERNEL_FTRACE` / `KERNEL_FUNCTION_TRACER` deps) by default when `KERNEL_DEBUG_INFO_BTF` is already selected -- the same eBPF-capable targets that already get NETKIT. Targets without BTF are unaffected.

Tested on x86_64 / 6.12.94: `/sys/kernel/debug/tracing/available_tracers` now lists `function` and `function_graph`, and dae logs `TCP relay eBPF offload enabled` on the fentry path.

(this PR recreates the previously closed #2453 after its source fork was deleted)