### PR TITLE
rockchip: fix modem reset GPIO on MangoPi M28C

### DIFF
--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3528-mangopi-m28c.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3528-mangopi-m28c.dts
@@ -14,7 +14,7 @@
 
 		modem-reset {
 			gpio-export,name = "MODEM-RST";
-			gpio-export,output = <0>;
+			gpio-export,output = <1>;
 			gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_LOW>;
 		};
 


### PR DESCRIPTION
Commit 0ca78951739a ("kernel: use fwnode for GPIO export driver")
  changed gpio-export output values to use the GPIO descriptor logical
  polarity.

  MODEM-RST is declared as GPIO_ACTIVE_LOW. Therefore, output <0> now
  drives the physical GPIO high, preventing the modem from enumerating
  on USB.

  Set the logical output to high so the active-low GPIO is driven low.

  Tested on a Widora MangoPi M28C with a Fibocom 2cb7:0104 modem. The
  modem enumerates automatically after a cold boot and exposes its
  serial, QMI and WWAN interfaces.